### PR TITLE
feat: add treefmt-nix with nixfmt formatter

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(ls:*)",
-      "Bash(gh issue:*)"
+      "Bash(gh issue:*)",
+      "Bash(nix fmt:*)"
     ],
     "deny": []
   }

--- a/flake.lock
+++ b/flake.lock
@@ -94,7 +94,28 @@
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
         "nixpkgs-arc-browser": "nixpkgs-arc-browser",
-        "nixpkgs-ghostty": "nixpkgs-ghostty"
+        "nixpkgs-ghostty": "nixpkgs-ghostty",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754492133,
+        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -15,17 +15,38 @@
 
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
+
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = inputs@{ self, nixpkgs, nixpkgs-ghostty, nixpkgs-arc-browser, nix-darwin, home-manager, ... }:
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      nixpkgs-ghostty,
+      nixpkgs-arc-browser,
+      nix-darwin,
+      home-manager,
+      treefmt-nix,
+      ...
+    }:
     let
       system = "aarch64-darwin";
       pkgs = import nixpkgs {
         inherit system;
         config.allowUnfree = true;
       };
-      ghostty = (import nixpkgs-ghostty { inherit system; config.allowUnfree = true; }).ghostty;
-      arc-browser = (import nixpkgs-arc-browser { inherit system; config.allowUnfree = true; }).arc-browser;
+      ghostty =
+        (import nixpkgs-ghostty {
+          inherit system;
+          config.allowUnfree = true;
+        }).ghostty;
+      arc-browser =
+        (import nixpkgs-arc-browser {
+          inherit system;
+          config.allowUnfree = true;
+        }).arc-browser;
     in
     {
       darwinConfigurations."Mac-big" = nix-darwin.lib.darwinSystem {
@@ -42,23 +63,28 @@
 
               programs.zsh.enable = true;
 
-              environment.systemPackages = (with pkgs; [
-                alt-tab-macos
-                devbox
-                discord
-                fzf
-                gh
-                ghq
-                git
-                mise
-                pnpm
-                raycast
-                superfile
-                tree
-                uv
-                vim
-                vscode
-              ]) ++ [ ghostty arc-browser ];
+              environment.systemPackages =
+                (with pkgs; [
+                  alt-tab-macos
+                  devbox
+                  discord
+                  fzf
+                  gh
+                  ghq
+                  git
+                  mise
+                  pnpm
+                  raycast
+                  superfile
+                  tree
+                  uv
+                  vim
+                  vscode
+                ])
+                ++ [
+                  ghostty
+                  arc-browser
+                ];
 
               nix.settings.experimental-features = "nix-command flakes";
 
@@ -77,6 +103,10 @@
         );
       };
 
-      formatter.${system} = pkgs.nixpkgs-fmt;
+      # Use treefmt for formatting with nixfmt
+      formatter.${system} = treefmt-nix.lib.mkWrapper pkgs {
+        projectRootFile = "flake.nix";
+        programs.nixfmt.enable = true;
+      };
     };
 }

--- a/home-manager/ghostty.nix
+++ b/home-manager/ghostty.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 let
   ghosttyConfig = ''

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   imports = [

--- a/home-manager/zsh.nix
+++ b/home-manager/zsh.nix
@@ -1,4 +1,5 @@
-{ config, pkgs, ... }: {
+{ config, pkgs, ... }:
+{
 
   programs.zsh = {
     enable = true;

--- a/nix-darwin/cursor.nix
+++ b/nix-darwin/cursor.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   system.defaults.NSGlobalDomain.KeyRepeat = 1;

--- a/nix-darwin/dock.nix
+++ b/nix-darwin/dock.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   system.defaults.dock = {

--- a/nix-darwin/finder.nix
+++ b/nix-darwin/finder.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   system.defaults.finder = {

--- a/nix-darwin/menubar.nix
+++ b/nix-darwin/menubar.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   system.defaults.NSGlobalDomain._HIHideMenuBar = true;

--- a/nix-darwin/screen_capture.nix
+++ b/nix-darwin/screen_capture.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   system.defaults.screencapture = {

--- a/nix-darwin/scroll.nix
+++ b/nix-darwin/scroll.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   system.defaults.NSGlobalDomain."com.apple.swipescrolldirection" = false;


### PR DESCRIPTION
## Summary
Configure proper Nix code formatting using treefmt-nix and nixfmt.

## Problem
- `nix fmt` without arguments waits for stdin indefinitely
- `nix fmt .` showed deprecation warning about passing directories
- nixpkgs-fmt was outdated and archived

## Solution
- Added treefmt-nix as a flake input for proper directory formatting
- Configured nixfmt (official Nix formatter) with RFC style
- Formatted all .nix files in the repository

## Changes
- Add treefmt-nix flake input
- Replace nixpkgs-fmt with nixfmt via treefmt wrapper
- Format all .nix files to follow RFC style guidelines

## Usage
Now you can format the entire project with:
```bash
nix fmt .
```

Fixes #49

🤖 Generated with [Claude Code](https://claude.ai/code)