### PR TITLE
fix: migrate git config to new home-manager API

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766963849,
-        "narHash": "sha256-9a1PTYJByzRUurF8Vb5kNXcO5HEBj9uGQMS7JoLUGTI=",
+        "lastModified": 1766969492,
+        "narHash": "sha256-TbvCOhB4ziljUQUOkqYAtKM0H4XJTR/1UQEB2n+NL4s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "87785ddbc70fbd379cf3ee0d1ebd778957172248",
+        "rev": "9d32c214dbdd66fff881d0d3aad91bde282bd37b",
         "type": "github"
       },
       "original": {

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -3,9 +3,11 @@
 {
   programs.git = {
     enable = true;
-    userName = "naitokosuke";
-    userEmail = "kosuke.naito.engineer@gmail.com";
-    extraConfig = {
+    settings = {
+      user = {
+        name = "naitokosuke";
+        email = "kosuke.naito.engineer@gmail.com";
+      };
       core.editor = "vim";
       init.defaultBranch = "main";
       ghq.root = "/Users/naitokosuke/src";


### PR DESCRIPTION
## Summary

- Migrate deprecated git config options to new `programs.git.settings` API
- `programs.git.userEmail` → `programs.git.settings.user.email`
- `programs.git.userName` → `programs.git.settings.user.name`
- `programs.git.extraConfig` → `programs.git.settings`

## Test plan

- [ ] Run `darwin-rebuild switch --flake .#Mac-big` and verify no warnings appear

Closes #91
Closes #100
Closes #101
Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)