### PR TITLE
fix(ghostty): disable font ligature for Japanese text

### DIFF
--- a/home-manager/ghostty.nix
+++ b/home-manager/ghostty.nix
@@ -8,6 +8,8 @@
 let
   ghosttyConfig = ''
     theme = "Catppuccin Mocha"
+    font-feature = -calt
+    font-feature = -dlig
   '';
 in
 {


### PR DESCRIPTION
## Summary

- Disable font ligatures that cause issues with Japanese text rendering
- Add `font-feature = -calt` to disable contextual alternates
- Add `font-feature = -dlig` to disable discretionary ligatures

This fixes the issue where Japanese text like "ます" is incorrectly rendered as "〼".

Reference: https://github.com/ghostty-org/ghostty/issues/5372#issuecomment-2614259192

Closes #93

## Test plan

- [ ] Run `darwin-rebuild switch --flake .#Mac-big`
- [ ] Verify Japanese text renders correctly in Ghostty (e.g., "ます" should not become "〼")

🤖 Generated with [Claude Code](https://claude.com/claude-code)