### PR TITLE
feat: migrate GUI apps to Homebrew Casks for version stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,36 +6,43 @@ Personal Nix configuration for macOS using [nix-darwin](https://github.com/LnL7/
 
 - macOS on Apple Silicon
 - Nix package manager
+- Xcode Command Line Tools (required for Homebrew)
 
 ## Installation
 
-1. Install Nix:
+1. Install Xcode Command Line Tools:
+   ```bash
+   xcode-select --install
+   ```
+
+2. Install Nix:
    ```bash
    sh <(curl -L https://nixos.org/nix/install)
    ```
 
-2. Clone this repository:
+3. Clone this repository:
    ```bash
    git clone https://github.com/naitokosuke/nix-config.git
    cd nix-config
    ```
 
-3. Apply the configuration:
+4. Apply the configuration:
    ```bash
    nix run nix-darwin --extra-experimental-features "nix-command flakes" -- switch --flake .#Mac-big
    ```
 
 ## Configuration Structure
 
-### System Configuration (`nix-darwin/`)
+### System Configuration (nix-darwin/)
 - `cursor.nix` - Cursor settings
 - `dock.nix` - Dock preferences
 - `finder.nix` - Finder preferences
+- `homebrew.nix` - Homebrew Casks (GUI apps)
 - `menubar.nix` - Menu bar settings
 - `scroll.nix` - Scrolling behavior
 - `screen_capture.nix` - Screen capture settings
 
-### User Configuration (`home-manager/`)
+### User Configuration (home-manager/)
 - `gh.nix` - GitHub CLI
 - `ghostty.nix` - Ghostty terminal
 - `git.nix` - Git configuration
@@ -44,12 +51,13 @@ Personal Nix configuration for macOS using [nix-darwin](https://github.com/LnL7/
 
 ### Packages
 
-- **Development**: git, gh, ghq, mise, devbox, uv, pnpm
-- **Terminal**: ghostty, vim, fzf, tree
-- **macOS utilities**: alt-tab-macos, raycast
-- **Applications**: arc-browser, discord, vscode
+CLI tools are managed via nixpkgs, GUI apps via Homebrew Casks.
 
-*Note: ghostty and arc-browser use pinned nixpkgs versions.*
+**CLI (nixpkgs)**:
+- devbox, fcp, fd, fzf, gh, ghq, git, mise, pnpm, ripgrep, tree, uv, vim
+
+**GUI (Homebrew Casks)**:
+- alt-tab, arc, discord, ghostty, google-chrome, raycast, scroll-reverser, visual-studio-code
 
 ## Customization
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "brew-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1763638478,
+        "narHash": "sha256-n/IMowE9S23ovmTkKX7KhxXC2Yq41EAVFR2FBIXPcT8=",
+        "owner": "Homebrew",
+        "repo": "brew",
+        "rev": "fbfdbaba008189499958a7aeb1e2c36ab10c067d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Homebrew",
+        "ref": "5.0.3",
+        "repo": "brew",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -17,6 +34,22 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "homebrew-cask": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767016898,
+        "narHash": "sha256-sQmF5gqhM/Nj2sxGw8Ovhbj2QKynH8t6zn6TV5C4I+Y=",
+        "owner": "homebrew",
+        "repo": "homebrew-cask",
+        "rev": "b3812b4b8b66c290555e3675495c7998f2047c13",
+        "type": "github"
+      },
+      "original": {
+        "owner": "homebrew",
+        "repo": "homebrew-cask",
         "type": "github"
       }
     },
@@ -40,6 +73,24 @@
         "type": "github"
       }
     },
+    "nix-homebrew": {
+      "inputs": {
+        "brew-src": "brew-src"
+      },
+      "locked": {
+        "lastModified": 1764473698,
+        "narHash": "sha256-C91gPgv6udN5WuIZWNehp8qdLqlrzX6iF/YyboOj6XI=",
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
+        "rev": "6a8ab60bfd66154feeaa1021fc3b32684814a62a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1766870016,
@@ -56,45 +107,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-arc-browser": {
-      "locked": {
-        "lastModified": 1749585634,
-        "narHash": "sha256-UnFzEFX39eYoYRIMcC8psp+fiF6pp1IyP0cyX1YCHMg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "bd18a431cb4013c146680abe8e878ffd4f9a03ca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "bd18a43",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-ghostty": {
-      "locked": {
-        "lastModified": 1735475203,
-        "narHash": "sha256-yEDjYGQ3qFXYSbtzUWZewH+d8IWakPROHrbTlkgXPiA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3187271a737d623ba3ebfa12ec3e8b66a0321542",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "3187271",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "homebrew-cask": "homebrew-cask",
         "nix-darwin": "nix-darwin",
+        "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-arc-browser": "nixpkgs-arc-browser",
-        "nixpkgs-ghostty": "nixpkgs-ghostty",
         "treefmt-nix": "treefmt-nix",
         "vscode-settings": "vscode-settings"
       }

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -2,6 +2,7 @@
   ./cursor.nix
   ./dock.nix
   ./finder.nix
+  ./homebrew.nix
   ./keyboard.nix
   ./menubar.nix
   ./scroll.nix

--- a/nix-darwin/homebrew.nix
+++ b/nix-darwin/homebrew.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, ... }:
+{
+  homebrew = {
+    enable = true;
+
+    onActivation = {
+      # Do not auto-update Homebrew during darwin-rebuild
+      autoUpdate = false;
+      # Do not upgrade already installed packages
+      upgrade = false;
+      # Do not remove packages not listed here (safe default)
+      cleanup = "none";
+    };
+
+    casks = [
+      "alt-tab"
+      "arc"
+      "discord"
+      "ghostty"
+      "google-chrome"
+      "raycast"
+      "scroll-reverser"
+      "visual-studio-code"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- Migrate GUI apps from nixpkgs to Homebrew Casks
- Introduce nix-homebrew to manage Homebrew itself via Nix
- CLI tools continue to be managed via nixpkgs

## Background

When managing GUI apps with nixpkgs, versions would revert to the `flake.lock` version during `darwin-rebuild switch`. This is due to Nix's reproducibility-focused design.

Following nix-darwin best practices, the configuration has been changed to:

| Category | Management |
|----------|------------|
| CLI tools | nixpkgs |
| GUI apps | Homebrew Casks |

## Changes

### New files

- `nix-darwin/homebrew.nix` - Declarative Homebrew Casks management

### Modified files

- `flake.nix`
  - Add `nix-homebrew` and `homebrew-cask` to inputs
  - Remove pinned nixpkgs (`nixpkgs-arc-browser`, `nixpkgs-ghostty`)
  - Remove GUI apps from `environment.systemPackages`
  - Configure nix-homebrew module

- `flake.lock`
  - Add new inputs
  - Remove unused inputs

- `nix-darwin/default.nix`
  - Add `homebrew.nix` to imports

- `README.md`
  - Add Xcode Command Line Tools to Prerequisites
  - Update package configuration description

## Migrated GUI Apps

| App | From | To |
|-----|------|-----|
| alt-tab-macos | nixpkgs | `alt-tab` (cask) |
| arc-browser | pinned nixpkgs | `arc` (cask) |
| discord | nixpkgs | `discord` (cask) |
| ghostty | pinned nixpkgs | `ghostty` (cask) |
| google-chrome | nixpkgs | `google-chrome` (cask) |
| raycast | nixpkgs | `raycast` (cask) |
| scroll-reverser | nixpkgs | `scroll-reverser` (cask) |
| vscode | nixpkgs | `visual-studio-code` (cask) |

## Configuration Details

### nix-homebrew

```nix
nix-homebrew = {
  enable = true;
  enableRosetta = true;      # Apple Silicon support
  user = "naitokosuke";
  autoMigrate = true;        # Auto-migrate existing Homebrew
  taps = {
    "homebrew/homebrew-cask" = homebrew-cask;
  };
  mutableTaps = false;       # Declarative tap management
};
```

### homebrew.nix

```nix
homebrew = {
  enable = true;
  onActivation = {
    autoUpdate = false;      # Don't auto-update on rebuild
    upgrade = false;         # Don't upgrade existing packages
    cleanup = "none";        # Leave unlisted apps alone
  };
  casks = [ ... ];
};
```

## Test

- [x] `darwin-rebuild switch --flake .#Mac-big` succeeded
- [x] All 8 apps installed via Homebrew Casks
- [x] Verified with `brew list --cask`

Closes #109
Closes #110
Closes #111
Closes #112
Closes #113
Closes #114
Closes #115
Closes #116
Closes #117
Closes #118
Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)