### PR TITLE
feat: Claude Code を Nix で管理する

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,24 @@
         "type": "github"
       }
     },
+    "claude-code-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1768172483,
+        "narHash": "sha256-dDsPt0w8QyQDaIKrOsTD0N8sou6TQ2VdMQ7C0Cw464M=",
+        "owner": "ryoppippi",
+        "repo": "claude-code-overlay",
+        "rev": "fd4cc28f8655f6e3ad210643ef63f814bb4c00d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryoppippi",
+        "repo": "claude-code-overlay",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -111,16 +129,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768149890,
-        "narHash": "sha256-iihg1oHkVkYHD1pFQifGEP+Rw1g+LZQyDNbtAqpXtNM=",
+        "lastModified": 1763835633,
+        "narHash": "sha256-HzxeGVID5MChuCPESuC0dlQL1/scDKu+MmzoVBJxulM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d113fe1f7bb454435a5cabae6cd283e64191bb7",
+        "rev": "050e09e091117c3d7328c7b2b7b577492c43c134",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -141,13 +159,30 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1768149890,
+        "narHash": "sha256-iihg1oHkVkYHD1pFQifGEP+Rw1g+LZQyDNbtAqpXtNM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d113fe1f7bb454435a5cabae6cd283e64191bb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "claude-code-overlay": "claude-code-overlay",
         "home-manager": "home-manager",
         "homebrew-cask": "homebrew-cask",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "treefmt-nix": "treefmt-nix",
         "vize": "vize",
         "vscode-settings": "vscode-settings"
@@ -191,7 +226,7 @@
     "vize": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1768198486,

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,8 @@
     vscode-settings.flake = false;
 
     vize.url = "github:naitokosuke/vize-nix";
+
+    claude-code-overlay.url = "github:ryoppippi/claude-code-overlay";
   };
 
   outputs =
@@ -37,6 +39,7 @@
       homebrew-cask,
       vscode-settings,
       vize,
+      claude-code-overlay,
       ...
     }:
     let
@@ -44,6 +47,7 @@
       pkgs = import nixpkgs {
         inherit system;
         config.allowUnfree = true;
+        overlays = [ claude-code-overlay.overlays.default ];
       };
 
       # Common Darwin system configuration
@@ -65,6 +69,7 @@
 
                 environment.systemPackages = with pkgs; [
                   bun
+                  claude-code
                   deno
                   devbox
                   devenv


### PR DESCRIPTION
## Summary

- ryoppippi/claude-code-overlay を使用して Claude Code CLI を Nix で宣言的に管理できるようにした

## Test plan

- [x] `darwin-rebuild switch --flake .#Mac-big` でビルド成功を確認

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)