### PR TITLE
Fix Claude code overlay issue

### DIFF
--- a/home/naitokosuke/claude.nix
+++ b/home/naitokosuke/claude.nix
@@ -21,6 +21,7 @@
       diffTool = "auto";
       env = {
         DISABLE_AUTOUPDATER = "1";
+        DISABLE_INSTALLATION_CHECKS = "1";
       };
       todoFeatureEnabled = true;
       messageIdleNotifThresholdMs = 60000;


### PR DESCRIPTION
Respond to upstream claude-code-overlay PR #10 changes. This suppresses path-related warnings for ~/.local/bin.

Closes #156