### PR TITLE
feat: migrate from Zsh to Nushell

### DIFF
--- a/home/naitokosuke/atuin.nix
+++ b/home/naitokosuke/atuin.nix
@@ -3,6 +3,7 @@
   programs.atuin = {
     enable = true;
     enableZshIntegration = true;
+    enableNushellIntegration = true;
 
     settings = {
       # Search mode: prefix, fulltext, fuzzy, skim

--- a/home/naitokosuke/direnv.nix
+++ b/home/naitokosuke/direnv.nix
@@ -4,5 +4,6 @@
   programs.direnv = {
     enable = true;
     nix-direnv.enable = true;
+    enableNushellIntegration = true;
   };
 }

--- a/home/naitokosuke/ghostty.nix
+++ b/home/naitokosuke/ghostty.nix
@@ -1,7 +1,10 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
   home.file.".config/ghostty/config".text = ''
+    # Use Nushell as the shell
+    command = ${pkgs.nushell}/bin/nu --login
+
     theme = "Catppuccin Mocha"
     font-feature = -calt
     font-feature = -dlig

--- a/home/naitokosuke/home.nix
+++ b/home/naitokosuke/home.nix
@@ -13,8 +13,9 @@
     ./gh.nix
     ./ghostty.nix
     ./git.nix
+    ./nushell.nix
     ./vscode.nix
-    ./zsh.nix
+    ./zsh.nix # Keep zsh for fallback and script compatibility
   ];
 
   # Home Manager needs a bit of information about you and the


### PR DESCRIPTION
## Summary

- Add Nushell configuration with PATH setup via `extraEnv`
- Configure Ghostty to launch Nushell as shell
- Enable Nushell integration for Atuin and direnv
- Keep zsh.nix for script compatibility

## Design Decision

Login shell is **not** changed because nix-darwin cannot manage it declaratively. Instead, Nushell is launched via Ghostty's `command` option.

See: [nix-darwin issue #1028](https://github.com/LnL7/nix-darwin/issues/1028)

## Test plan

- [x] Ghostty launches Nushell
- [x] PATH includes Nix/Homebrew paths
- [x] Aliases work (`cl`, `l`, `la`, etc.)
- [x] Atuin integration works
- [x] direnv integration works

Closes #132

🤖 Generated with [Claude Code](https://claude.ai/code)