### PR TITLE
feat: add Starship prompt

### DIFF
--- a/home/naitokosuke/home.nix
+++ b/home/naitokosuke/home.nix
@@ -14,6 +14,7 @@
     ./ghostty.nix
     ./git.nix
     ./nushell.nix
+    ./starship.nix
     ./vscode.nix
   ];
 

--- a/home/naitokosuke/nushell.nix
+++ b/home/naitokosuke/nushell.nix
@@ -45,13 +45,6 @@
 
     # Extra configuration (config.nu)
     extraConfig = ''
-      # Custom prompt
-      $env.PROMPT_COMMAND = {||
-        let path = ($env.PWD | str replace $env.HOME '~')
-        $"(ansi green_bold)($env.USER)(ansi reset) at (ansi yellow)($env.HOSTNAME? | default 'mac')(ansi reset) in (ansi green_bold)($path)(ansi reset)\n(ansi green)❯(ansi reset) "
-      }
-      $env.PROMPT_INDICATOR = ""
-
       # Custom function: mkcd
       def mkcd [dir: string] {
         mkdir $dir

--- a/home/naitokosuke/starship.nix
+++ b/home/naitokosuke/starship.nix
@@ -1,0 +1,66 @@
+{ config, pkgs, ... }:
+
+{
+  programs.starship = {
+    enable = true;
+
+    # Enable for Nushell
+    enableNushellIntegration = true;
+
+    # Starship configuration
+    settings = {
+      # Add newline before prompt
+      add_newline = true;
+
+      # Prompt format
+      format = "$username$hostname$directory$git_branch$git_status$cmd_duration$line_break$character";
+
+      # Character module (prompt indicator)
+      character = {
+        success_symbol = "[❯](green)";
+        error_symbol = "[❯](red)";
+      };
+
+      # Username
+      username = {
+        show_always = true;
+        style_user = "green bold";
+        format = "[$user]($style) ";
+      };
+
+      # Hostname
+      hostname = {
+        ssh_only = false;
+        style = "yellow";
+        format = "at [$hostname]($style) ";
+      };
+
+      # Directory
+      directory = {
+        style = "green bold";
+        format = "in [$path]($style) ";
+        truncation_length = 5;
+        truncate_to_repo = false;
+      };
+
+      # Git branch
+      git_branch = {
+        style = "purple bold";
+        format = "on [$symbol$branch]($style) ";
+      };
+
+      # Git status
+      git_status = {
+        style = "red bold";
+        format = "([$all_status$ahead_behind]($style))";
+      };
+
+      # Command duration
+      cmd_duration = {
+        min_time = 2000;
+        style = "yellow";
+        format = "took [$duration]($style) ";
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Starship プロンプトを導入
- Nushell 連携を有効化
- 既存のカスタムプロンプトを Starship に置き換え

## Test plan

- [ ] `darwin-rebuild switch --flake .#Mac-big` を実行
- [ ] 新しいターミナルを開いて Starship プロンプトが表示されることを確認
- [ ] Git リポジトリでブランチ名とステータスが表示されることを確認

Closes #158

🤖 Generated with [Claude Code](https://claude.ai/code)