### PR TITLE
feat: add HOMEBREW_FORBIDDEN_FORMULAE to prevent accidental brew install

### DIFF
--- a/home/naitokosuke/nushell.nix
+++ b/home/naitokosuke/nushell.nix
@@ -1,5 +1,32 @@
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
+let
+  # Packages managed by Nix - prevent accidental brew install
+  # See: https://github.com/Homebrew/brew/issues/19939
+  homebrewForbiddenFormulae = [
+    "bun"
+    "claude"
+    "deno"
+    "fd"
+    "fzf"
+    "gh"
+    "git"
+    "node"
+    "npm"
+    "pip"
+    "pnpm"
+    "python"
+    "python3"
+    "ripgrep"
+    "vim"
+    "yarn"
+  ];
+in
 {
   programs.nushell = {
     enable = true;
@@ -19,6 +46,7 @@
     # Environment variables
     environmentVariables = {
       EDITOR = "vim";
+      HOMEBREW_FORBIDDEN_FORMULAE = lib.concatStringsSep " " homebrewForbiddenFormulae;
     };
 
     # Extra env configuration (env.nu) - runs before config.nu


### PR DESCRIPTION
## Summary

- Nix で管理しているパッケージを誤って Homebrew でインストールすることを防ぐ `HOMEBREW_FORBIDDEN_FORMULAE` 環境変数を追加
- 配列で定義して管理しやすい形に

## Reference

- https://github.com/Homebrew/brew/issues/19939

## Test plan

- [x] `darwin-rebuild switch` で設定を適用
- [x] `brew install node` でブロックされることを確認

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)