### PR TITLE
refactor: organize shell config into shell/ directory

### DIFF
--- a/home/naitokosuke/home.nix
+++ b/home/naitokosuke/home.nix
@@ -13,7 +13,7 @@
     ./gh.nix
     ./ghostty.nix
     ./git.nix
-    ./nushell.nix
+    ./shell
     ./starship.nix
     ./vscode.nix
   ];

--- a/home/naitokosuke/shell/common.nix
+++ b/home/naitokosuke/shell/common.nix
@@ -1,0 +1,62 @@
+# Common shell configuration shared between Nushell and Zsh
+#
+# This file centralizes settings that should be consistent across shells:
+# - PATH configuration
+# - Environment variables
+# - Homebrew forbidden formulae list
+# - Common aliases
+#
+# Import this in shell-specific modules to avoid duplication.
+{ lib, ... }:
+
+{
+  # Packages managed by Nix - prevent accidental brew install
+  # See: https://github.com/Homebrew/brew/issues/19939
+  homebrewForbiddenFormulae = [
+    "bun"
+    "claude"
+    "deno"
+    "fd"
+    "fzf"
+    "gh"
+    "git"
+    "node"
+    "npm"
+    "pip"
+    "pnpm"
+    "python"
+    "python3"
+    "ripgrep"
+    "vim"
+    "yarn"
+  ];
+
+  # Common environment variables
+  envVars = {
+    EDITOR = "vim";
+  };
+
+  # Common shell aliases (POSIX-compatible syntax)
+  aliases = {
+    l = "ls";
+    la = "ls -la";
+    ll = "ls -l";
+    ":q" = "exit";
+
+    # for antfu/ni
+    nid = "ni -D";
+  };
+
+  # PATH entries in priority order (last = highest priority)
+  # Each shell prepends these in order, so the last entry ends up first in $PATH
+  pathEntries = [
+    "/usr/local/bin"
+    "/opt/homebrew/sbin"
+    "/opt/homebrew/bin"
+    "/nix/var/nix/profiles/default/bin"
+    "/run/current-system/sw/bin"
+    "/etc/profiles/per-user/naitokosuke/bin"
+    # Note: $HOME/.nix-profile/bin is handled separately in each shell
+    # because of different variable expansion syntax
+  ];
+}

--- a/home/naitokosuke/shell/default.nix
+++ b/home/naitokosuke/shell/default.nix
@@ -1,0 +1,12 @@
+# Shell configurations aggregator
+#
+# Manages both Nushell (interactive terminal) and Zsh (login shell for IDE/CLI tools).
+# Common settings (PATH, env vars, aliases) are defined in common.nix.
+{ ... }:
+
+{
+  imports = [
+    ./nushell.nix
+    ./zsh.nix
+  ];
+}

--- a/home/naitokosuke/shell/zsh.nix
+++ b/home/naitokosuke/shell/zsh.nix
@@ -1,0 +1,47 @@
+# Zsh configuration (login shell)
+#
+# Zsh is the login shell on macOS, used by:
+# - Claude Code (VSCode extension)
+# - Other IDE integrations
+# - SSH sessions
+# - Terminal emulators (as login shell)
+#
+# Nushell is used as the interactive shell in Ghostty terminal,
+# but Zsh handles login shell responsibilities.
+#
+# PATH is configured in .zprofile (not .zshenv) per Nix best practices.
+# See: https://github.com/nix-community/home-manager/issues/2991
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  common = import ./common.nix { inherit lib; };
+in
+{
+  programs.zsh = {
+    enable = true;
+
+    # Environment variables
+    sessionVariables = common.envVars // {
+      HOMEBREW_FORBIDDEN_FORMULAE = lib.concatStringsSep " " common.homebrewForbiddenFormulae;
+    };
+
+    # PATH configuration (added to .zprofile)
+    # profileExtra runs in login shells (terminal, SSH, IDE integrations)
+    # Note: .zshenv is not recommended for PATH (see home-manager#2991)
+    profileExtra = ''
+      # Add paths from common config (last entry becomes first in $PATH)
+      ${lib.concatMapStringsSep "\n" (p: "export PATH=\"${p}:$PATH\"") common.pathEntries}
+      export PATH="$HOME/.nix-profile/bin:$PATH"
+    '';
+
+    # Shell aliases (inherit common + zsh-specific)
+    shellAliases = common.aliases // {
+      cl = "clear";
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- シェル設定を `shell/` ディレクトリに整理
- Nushell と Zsh で共通の設定を `common.nix` で一元管理
- PATH 設定を `.zprofile` に配置（Nix ベストプラクティス）

## Test plan

- [ ] `darwin-rebuild switch --flake .#Mac-big` が成功する
- [ ] Claude Code で Nix 管理のコマンド（`gh`, `git` など）が使用できる
- [ ] Ghostty ターミナルで Nushell が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)