### PR TITLE
docs: update CLAUDE.md and README.md to reflect current structure

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Nix configuration repository for macOS that uses:
 - nix-darwin: System-level macOS configurations
-- home-manager: User-specific configurations  
+- home-manager: User-specific configurations
 - Nix Flakes: Reproducible dependency management
 
 The configuration targets Apple Silicon Macs (aarch64-darwin) and manages both system settings and user environments declaratively.
@@ -32,23 +32,47 @@ nix flake update
 
 The codebase follows a modular structure:
 
-- flake.nix: Entry point defining the Darwin system configuration. Contains package lists and system settings.
-- nix-darwin/: System-level macOS settings (dock, finder, cursor, etc.)
-  - Each module exports specific macOS system preferences
-  - Imported via `default.nix` which aggregates all modules
-- home-manager/: User-specific configurations
-  - `home.nix`: Main entry point that imports other modules
-  - Individual modules for git, zsh, ghostty terminal, GitHub CLI, VSCode settings sync
+```
+.
+├── flake.nix          # Entry point with package lists and system configuration
+├── hosts/             # System-level macOS settings (nix-darwin)
+│   ├── common/        # Shared settings for all hosts
+│   │   ├── cursor.nix
+│   │   ├── dock.nix
+│   │   ├── finder.nix
+│   │   ├── homebrew.nix
+│   │   ├── keyboard.nix
+│   │   ├── menubar.nix
+│   │   ├── rosetta.nix
+│   │   ├── screen_capture.nix
+│   │   └── scroll.nix
+│   ├── Mac-big/       # Mac mini specific settings
+│   └── Macbook-heavy/ # MacBook Air specific settings
+└── home/              # User-specific configurations (home-manager)
+    └── naitokosuke/
+        ├── home.nix   # Main entry point
+        ├── atuin.nix  # Shell history with Atuin
+        ├── claude.nix # Claude Code configuration
+        ├── direnv.nix # Directory-based environments
+        ├── gh.nix     # GitHub CLI
+        ├── ghostty.nix# Ghostty terminal
+        ├── git.nix    # Git configuration
+        ├── starship.nix # Starship prompt
+        ├── vscode.nix # VSCode settings sync
+        └── shell/     # Shell configurations
+            ├── nushell.nix  # Nushell (primary shell)
+            └── zsh.nix      # Zsh (fallback)
+```
 
 ## Key Development Patterns
 
-1. Adding System Settings: Create a new `.nix` file in `nix-darwin/` and add it to the imports in `default.nix`
+1. Adding System Settings: Create a new `.nix` file in `hosts/common/` and add it to the imports in `default.nix`
 
-2. Adding User Configurations: Create a new `.nix` file in `home-manager/` and import it in `home.nix`
+2. Adding User Configurations: Create a new `.nix` file in `home/naitokosuke/` and import it in `home.nix`
 
-3. Package Management: 
-   - System packages: Add to `environment.systemPackages` in flake.nix:36-65
-   - Broken packages use pinned nixpkgs versions via overlays (see ghostty/arc-browser in flake.nix:26-31)
+3. Package Management:
+   - System packages: Add to `environment.systemPackages` in flake.nix (around line 71-95)
+   - GUI apps: Add to Homebrew Casks in `hosts/common/homebrew.nix`
 
 4. Module Structure: Each nix module typically follows:
    ```nix
@@ -99,20 +123,21 @@ When creating markdown documentation, follow the rules defined in `~/src/github.
 
 ## Important Configuration Details
 
-- Hostname: "Mac-big" (defined in flake.nix:39)
-- User: "naitokosuke" (referenced in flake.nix:77)
+- Hosts: "Mac-big" (Mac mini), "Macbook-heavy" (MacBook Air)
+- User: "naitokosuke"
 - System: "aarch64-darwin" (Apple Silicon)
+- Primary shell: Nushell (with Zsh as fallback)
 - Experimental features enabled: nix-command, flakes
 
 ## VSCode Settings Sync
 
 The repository includes automatic VSCode settings synchronization from GitHub repository `naitokosuke/vscode-settings`:
 
-- **Module**: `home-manager/vscode.nix`
-- **Settings Path**: `~/Library/Application Support/Code/User/settings.json`
-- **Keybindings Path**: `~/Library/Application Support/Code/User/keybindings.json`
-- **Backup**: Existing files are automatically backed up with `.backup` extension
-- **JSONC Support**: Keybindings are converted from JSONC to JSON format automatically
+- Module: `home/naitokosuke/vscode.nix`
+- Settings Path: `~/Library/Application Support/Code/User/settings.json`
+- Keybindings Path: `~/Library/Application Support/Code/User/keybindings.json`
+- Backup: Existing files are automatically backed up with `.backup` extension
+- JSONC Support: Keybindings are converted from JSONC to JSON format automatically
 
 ### Updating VSCode Settings
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Personal Nix configuration for macOS using [nix-darwin](https://github.com/LnL7/
 
 3. Clone this repository:
    ```bash
-   git clone https://github.com/naitokosuke/nix-config.git
-   cd nix-config
+   git clone https://github.com/naitokosuke/dotfiles.git
+   cd dotfiles
    ```
 
 4. Apply the configuration:
@@ -33,37 +33,60 @@ Personal Nix configuration for macOS using [nix-darwin](https://github.com/LnL7/
 
 ## Configuration Structure
 
-### System Configuration (nix-darwin/)
+```
+.
+├── flake.nix          # Entry point with package lists and system configuration
+├── hosts/             # System-level macOS settings (nix-darwin)
+│   ├── common/        # Shared settings for all hosts
+│   ├── Mac-big/       # Mac mini specific settings
+│   └── Macbook-heavy/ # MacBook Air specific settings
+└── home/              # User-specific configurations (home-manager)
+    └── naitokosuke/
+        ├── home.nix   # Main entry point
+        ├── shell/     # Shell configurations (Nushell, Zsh)
+        └── ...        # Other modules (git, gh, vscode, etc.)
+```
+
+### System Configuration (hosts/common/)
+
 - `cursor.nix` - Cursor settings
 - `dock.nix` - Dock preferences
 - `finder.nix` - Finder preferences
 - `homebrew.nix` - Homebrew Casks (GUI apps)
+- `keyboard.nix` - Keyboard settings
 - `menubar.nix` - Menu bar settings
-- `scroll.nix` - Scrolling behavior
+- `rosetta.nix` - Rosetta 2 for Intel compatibility
 - `screen_capture.nix` - Screen capture settings
+- `scroll.nix` - Scrolling behavior
 
-### User Configuration (home-manager/)
+### User Configuration (home/naitokosuke/)
+
+- `shell/nushell.nix` - Nushell (primary shell)
+- `shell/zsh.nix` - Zsh (fallback shell)
+- `atuin.nix` - Shell history with Atuin
+- `claude.nix` - Claude Code configuration
+- `direnv.nix` - Directory-based environments
 - `gh.nix` - GitHub CLI
 - `ghostty.nix` - Ghostty terminal
 - `git.nix` - Git configuration
+- `starship.nix` - Starship prompt
 - `vscode.nix` - VSCode settings sync
-- `zsh.nix` - Zsh shell
 
 ### Packages
 
 CLI tools are managed via nixpkgs, GUI apps via Homebrew Casks.
 
 **CLI (nixpkgs)**:
-- devbox, fcp, fd, fzf, gh, ghq, git, mise, pnpm, ripgrep, tree, uv, vim
+- bun, claude-code, deno, devbox, devenv, fcp, fd, fzf, gh, ghq, git, gomi, ni, nodejs, pnpm, ripgrep, rustup, tree, uv, vim
 
 **GUI (Homebrew Casks)**:
 - alt-tab, arc, discord, ghostty, google-chrome, raycast, scroll-reverser, visual-studio-code
 
 ## Customization
 
-1. Update `flake.nix`: hostname, computerName, primaryUser
-2. Update `home-manager/home.nix`: username, homeDirectory
-3. Update `home-manager/git.nix`: userName, userEmail, ghq.root
+1. Update `flake.nix`: Add packages to `environment.systemPackages`
+2. Update `hosts/common/`: Add or modify system settings
+3. Update `home/naitokosuke/`: Add or modify user configurations
 
 ## Usage
 


### PR DESCRIPTION
Closes #173  
Closes #174

- Update directory structure: nix-darwin/ → hosts/, home-manager/ → home/naitokosuke/
- Update shell info: zsh → Nushell (primary) with Zsh fallback
- Add new modules: atuin, claude, direnv, starship, shell/
- Update package lists to match current flake.nix
- Fix repository clone URL in README.md

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
