### PR TITLE
feat: migrate gh extensions to declarative management

### DIFF
--- a/home/naitokosuke/gh.nix
+++ b/home/naitokosuke/gh.nix
@@ -4,10 +4,25 @@
   lib,
   ...
 }:
+let
+  gh-sub-issue = pkgs.buildGoModule rec {
+    pname = "gh-sub-issue";
+    version = "0.5.1";
 
+    src = pkgs.fetchFromGitHub {
+      owner = "yahsan2";
+      repo = "gh-sub-issue";
+      rev = "v${version}";
+      hash = "sha256-WeQFWa+9dPiyInpDQx52vv9VNOzHrcPJi093WG2nmpA=";
+    };
+
+    vendorHash = "sha256-U4z6S12j9PBAXHNIQT8GgjEELqc6KTeeSVQnoF9Lw2I=";
+  };
+in
 {
   programs.gh = {
     enable = true;
+    extensions = [ gh-sub-issue ];
     settings = {
       version = 1;
       git_protocol = "ssh";
@@ -19,8 +34,4 @@
       };
     };
   };
-
-  home.activation.installGhExtensions = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    ${pkgs.gh}/bin/gh extension install yahsan2/gh-sub-issue 2>/dev/null || true
-  '';
 }


### PR DESCRIPTION
## Summary

- Replace imperative `gh extension install` in `home.activation` with declarative `programs.gh.extensions`
- Package `gh-sub-issue` as a `buildGoModule` derivation directly in `gh.nix`
- Remove network dependency at build time by using fixed-output derivation hashes

Closes #204

## Test plan

- [x] `nix fmt` passes
- [x] `nix build .#darwinConfigurations.Mac-big.system` succeeds
- [x] `darwin-rebuild switch --flake .#Mac-big` applies successfully
- [x] `gh extension list` shows `gh sub-issue`
- [x] `gh sub-issue` command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)