### PR TITLE
feat: add Claude Code ExitPlanMode hook

### DIFF
--- a/home/naitokosuke/claude.nix
+++ b/home/naitokosuke/claude.nix
@@ -61,6 +61,24 @@
       [ ! -f "$serena_config" ] && run cp ${serenaConfigContent} "$serena_config"
     '';
 
+  # Claude Code local settings (hooks)
+  home.file.".claude/settings.local.json".text = builtins.toJSON {
+    hooks = {
+      PreToolUse = [
+        {
+          matcher = "ExitPlanMode";
+          hooks = [
+            {
+              type = "command";
+              command = ''code "$(ls -t ~/.claude/plans/*.md | head -1)"'';
+              timeout = 5;
+            }
+          ];
+        }
+      ];
+    };
+  };
+
   # Claude Code rules - symlink to rule-rule-rule repository
   home.file.".claude/rules".source =
     config.lib.file.mkOutOfStoreSymlink "/Users/naitokosuke/src/github.com/naitokosuke/rule-rule-rule";


### PR DESCRIPTION
## Summary

- Add `settings.local.json` with a `PreToolUse` hook for `ExitPlanMode`
- Automatically opens the latest plan file in VS Code when exiting plan mode

Closes #190

## Test plan

- [x] `nix fmt` passes
- [x] `nix build .#darwinConfigurations.Mac-big.system` succeeds
- [ ] `darwin-rebuild switch --flake .#Mac-big` applies successfully
- [ ] ExitPlanMode triggers VS Code to open the plan file

🤖 Generated with [Claude Code](https://claude.com/claude-code)