### PR TITLE
feat: migrate from Determinate Systems Nix to Lix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Personal Nix configuration for macOS using [nix-darwin](https://github.com/LnL7/
 ## Prerequisites
 
 - macOS on Apple Silicon
-- Nix package manager
+- [Lix](https://lix.systems/) package manager
 - Xcode Command Line Tools (required for Homebrew)
 
 ## Installation
@@ -15,9 +15,9 @@ Personal Nix configuration for macOS using [nix-darwin](https://github.com/LnL7/
    xcode-select --install
    ```
 
-2. Install Nix:
+2. Install Lix:
    ```bash
-   sh <(curl -L https://nixos.org/nix/install)
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.lix.systems/lix | sh -s -- install
    ```
 
 3. Clone this repository:

--- a/hosts/common/nix.nix
+++ b/hosts/common/nix.nix
@@ -1,10 +1,12 @@
 {
   self,
+  pkgs,
   ...
 }:
 {
   programs.zsh.enable = false;
 
+  nix.package = pkgs.lix;
   nix.settings.experimental-features = "nix-command flakes";
   nix.settings.trusted-users = [
     "root"


### PR DESCRIPTION
## Summary

- `hosts/common/nix.nix` に `nix.package = pkgs.lix;` を追加し、nix-darwin が管理する Nix 実装を Lix に切り替え
- `README.md` のインストール手順を Lix インストーラーに更新

## Migration Steps

この PR をマージした後、以下の手順で移行する:

1. Determinate Systems Nix をアンインストール:
   ```bash
   /nix/nix-installer uninstall
   ```

2. Lix をインストール:
   ```bash
   curl --proto '=https' --tlsv1.2 -sSf -L https://install.lix.systems/lix | sh -s -- install
   ```

3. 設定を適用:
   ```bash
   darwin-rebuild switch --flake .#Mac-big
   ```

4. Lix が動作していることを確認:
   ```bash
   nix --version
   ```
   出力に `Lix` が含まれていれば OK。

## References

- [Lix | Installing Lix](https://lix.systems/install/)
- [Lix | Switching To Lix](https://lix.systems/add-to-config/)
- [lix-project/lix-installer](https://git.lix.systems/lix-project/lix-installer)

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)