### PR TITLE
Split extraActivation into separate named activation scripts

### DIFF
--- a/hosts/common/homebrew.nix
+++ b/hosts/common/homebrew.nix
@@ -1,8 +1,8 @@
 { config, pkgs, ... }:
 {
   # Remove Taps symlink and create writable directory before homebrew activation
-  # extraActivation runs before homebrew in nix-darwin's hardcoded order
-  system.activationScripts.extraActivation.text = ''
+  # This runs before homebrew activation in nix-darwin's hardcoded order
+  system.activationScripts.fixHomebrewTaps.text = ''
     TAPS_DIR="/opt/homebrew/Library/Taps"
     # Remove symlink to Nix store if exists
     if [ -L "$TAPS_DIR" ]; then

--- a/hosts/common/rosetta.nix
+++ b/hosts/common/rosetta.nix
@@ -8,7 +8,7 @@
 {
   # Install Rosetta 2 for Intel binary compatibility on Apple Silicon
   # Reference: https://github.com/LnL7/nix-darwin/issues/786
-  system.activationScripts.extraActivation.text = ''
+  system.activationScripts.installRosetta.text = ''
     softwareupdate --install-rosetta --agree-to-license || true
   '';
 }


### PR DESCRIPTION
## Summary
- Rename `system.activationScripts.extraActivation` in `rosetta.nix` to `installRosetta`
- Rename `system.activationScripts.extraActivation` in `homebrew.nix` to `fixHomebrewTaps`
- Both scripts were assigning to the same attribute path, causing one to silently override the other

## Test plan
- [ ] Run `darwin-rebuild switch --flake .#Mac-big` and verify both Rosetta install and Homebrew taps fix execute

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)