### PR TITLE
Move nu_scripts from fetchFromGitHub to flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -197,6 +197,22 @@
         "type": "github"
       }
     },
+    "nu-scripts": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770900822,
+        "narHash": "sha256-KRZtbZTzkQvizZSkorLnYpqI70lE8y4ERtbPQkb6ALo=",
+        "owner": "nushell",
+        "repo": "nu_scripts",
+        "rev": "cc94140f4942116e065a97d73c3ce430a092fef2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nushell",
+        "repo": "nu_scripts",
+        "type": "github"
+      }
+    },
     "octorus": {
       "inputs": {
         "nixpkgs": "nixpkgs_3"
@@ -223,6 +239,7 @@
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs_2",
+        "nu-scripts": "nu-scripts",
         "octorus": "octorus",
         "treefmt-nix": "treefmt-nix_2",
         "vize": "vize",

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,11 @@
     octorus.url = "github:naitokosuke/octorus-nix";
 
     llm-agents.url = "github:numtide/llm-agents.nix";
+
+    nu-scripts = {
+      url = "github:nushell/nu_scripts";
+      flake = false;
+    };
   };
 
   outputs =
@@ -43,6 +48,7 @@
       vize,
       octorus,
       llm-agents,
+      nu-scripts,
       ...
     }:
     let
@@ -63,6 +69,7 @@
               octorus
               vscode-settings
               homebrew-cask
+              nu-scripts
               ;
           };
           modules = [

--- a/home/naitokosuke/shell/nushell.nix
+++ b/home/naitokosuke/shell/nushell.nix
@@ -9,20 +9,12 @@
   config,
   pkgs,
   lib,
+  nu-scripts,
   ...
 }:
 
 let
   common = import ./common.nix { inherit lib; };
-
-  # nu_scripts for completions
-  # https://github.com/nushell/nu_scripts
-  nu-scripts = pkgs.fetchFromGitHub {
-    owner = "nushell";
-    repo = "nu_scripts";
-    rev = "main";
-    sha256 = "sha256-KfnxoyLY8F0jx6h/SGQb5hkTBHgaa0fktE1qM4BKTBc=";
-  };
 in
 {
   programs.nushell = {

--- a/hosts/common/home-manager.nix
+++ b/hosts/common/home-manager.nix
@@ -1,5 +1,6 @@
 {
   vscode-settings,
+  nu-scripts,
   ...
 }:
 {
@@ -8,6 +9,6 @@
   home-manager.backupFileExtension = "backup";
   home-manager.users.naitokosuke = import ../../home/naitokosuke/home.nix;
   home-manager.extraSpecialArgs = {
-    inherit vscode-settings;
+    inherit vscode-settings nu-scripts;
   };
 }


### PR DESCRIPTION
## Summary
- Add `nu-scripts` as a flake input (`flake = false`) instead of using `fetchFromGitHub` with `rev = "main"`
- Pass `nu-scripts` through `specialArgs` and `extraSpecialArgs` to home-manager modules
- Remove hardcoded `sha256` hash from `nushell.nix`

## Test plan
- [ ] Run `darwin-rebuild switch --flake .#Mac-big` and verify Nushell completions still work
- [ ] Verify `nix flake update nu-scripts` updates the input correctly

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)