### PR TITLE
Convert hosts/common/default.nix to standard module format

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,9 +76,9 @@
             }
             home-manager.darwinModules.home-manager
             nix-homebrew.darwinModules.nix-homebrew
-          ]
-          ++ (import ./hosts/common)
-          ++ [ (import ./hosts/${hostName}) ];
+            ./hosts/common
+            ./hosts/${hostName}
+          ];
         };
     in
     {

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -1,16 +1,19 @@
-[
-  ./cursor.nix
-  ./dock.nix
-  ./finder.nix
-  ./gomi.nix
-  ./home-manager.nix
-  ./homebrew.nix
-  ./keyboard.nix
-  ./menubar.nix
-  ./nix.nix
-  ./nix-homebrew.nix
-  ./packages.nix
-  ./rosetta.nix
-  ./scroll.nix
-  ./screen_capture.nix
-]
+{ ... }:
+{
+  imports = [
+    ./cursor.nix
+    ./dock.nix
+    ./finder.nix
+    ./gomi.nix
+    ./home-manager.nix
+    ./homebrew.nix
+    ./keyboard.nix
+    ./menubar.nix
+    ./nix.nix
+    ./nix-homebrew.nix
+    ./packages.nix
+    ./rosetta.nix
+    ./scroll.nix
+    ./screen_capture.nix
+  ];
+}


### PR DESCRIPTION
## Summary
- Change `hosts/common/default.nix` from returning a raw import list to using `{ ... }: { imports = [...]; }`
- Simplify `flake.nix` to use direct module paths instead of list concatenation with `++ (import ./hosts/common)`

## Test plan
- [ ] Run `darwin-rebuild switch --flake .#Mac-big` and verify all host configurations still apply

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)