### PR TITLE
Simplify vize/octorus package references via specialArgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,11 +59,11 @@
           specialArgs = {
             inherit
               self
-              vize
-              octorus
               vscode-settings
               homebrew-cask
               ;
+            vize-pkg = vize.packages.${system}.default;
+            octorus-pkg = octorus.packages.${system}.default;
           };
           modules = [
             {

--- a/hosts/common/packages.nix
+++ b/hosts/common/packages.nix
@@ -1,34 +1,32 @@
 {
   pkgs,
-  vize,
-  octorus,
+  vize-pkg,
+  octorus-pkg,
   ...
 }:
 {
-  environment.systemPackages =
-    with pkgs;
-    [
-      bun
-      llm-agents.claude-code
-      deno
-      devbox
-      devenv
-      fcp
-      fd
-      fzf
-      gh
-      ghq
-      git
-      gomi
-      ni
-      nodejs_24
-      pnpm
-      ripgrep
-      rustup
-      tree
-      uv
-      vim
-    ]
-    ++ [ vize.packages.${pkgs.stdenv.hostPlatform.system}.default ]
-    ++ [ octorus.packages.${pkgs.stdenv.hostPlatform.system}.default ];
+  environment.systemPackages = with pkgs; [
+    bun
+    llm-agents.claude-code
+    deno
+    devbox
+    devenv
+    fcp
+    fd
+    fzf
+    gh
+    ghq
+    git
+    gomi
+    ni
+    nodejs_24
+    pnpm
+    ripgrep
+    rustup
+    tree
+    uv
+    vim
+    vize-pkg
+    octorus-pkg
+  ];
 }


### PR DESCRIPTION
## Summary
- Resolve vize and octorus packages in `flake.nix` and pass them as `vize-pkg` / `octorus-pkg` through `specialArgs`
- Remove verbose `vize.packages.${pkgs.stdenv.hostPlatform.system}.default` patterns from `packages.nix`
- Include both packages directly in the `with pkgs` list for cleaner syntax

## Test plan
- [ ] Run `darwin-rebuild switch --flake .#Mac-big` and verify vize and octorus are still available

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)