### PR TITLE
Replace hardcoded user paths with config variables

### DIFF
--- a/home/naitokosuke/claude.nix
+++ b/home/naitokosuke/claude.nix
@@ -77,11 +77,11 @@
 
   # Claude Code rules - symlink to rule-rule-rule repository
   home.file.".claude/rules".source =
-    config.lib.file.mkOutOfStoreSymlink "/Users/naitokosuke/src/github.com/naitokosuke/rule-rule-rule";
+    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/github.com/${config.home.username}/rule-rule-rule";
 
   # Claude Code skills - symlink to skill-skill-skill repository
   home.file.".claude/skills".source =
-    config.lib.file.mkOutOfStoreSymlink "/Users/naitokosuke/src/github.com/naitokosuke/skill-skill-skill";
+    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/github.com/${config.home.username}/skill-skill-skill";
 
   # Global Claude Code memory
   home.file.".claude/CLAUDE.md".text = ''

--- a/home/naitokosuke/git.nix
+++ b/home/naitokosuke/git.nix
@@ -10,7 +10,7 @@
       };
       core.editor = "vim";
       init.defaultBranch = "main";
-      ghq.root = "/Users/naitokosuke/src";
+      ghq.root = "${config.home.homeDirectory}/src";
       push.autoSetupRemote = true;
       url."git@github.com:".insteadOf = "https://github.com/";
     };

--- a/home/naitokosuke/shell/nushell.nix
+++ b/home/naitokosuke/shell/nushell.nix
@@ -68,7 +68,7 @@ in
 
       # Default directory on terminal launch (non-VSCode)
       if ($env.VSCODE_GIT_IPC_HANDLE? | is-empty) and ($env.TERM_PROGRAM? != "vscode") {
-        cd /Users/naitokosuke/src/github.com/naitokosuke
+        cd ${config.home.homeDirectory}/src/github.com/${config.home.username}
       }
     '';
   };

--- a/hosts/common/screen_capture.nix
+++ b/hosts/common/screen_capture.nix
@@ -1,7 +1,7 @@
-{ ... }:
+{ config, ... }:
 
 {
   system.defaults.screencapture = {
-    location = "/Users/naitokosuke/Pictures/screen_shots/";
+    location = "/Users/${config.system.primaryUser}/Pictures/screen_shots/";
   };
 }


### PR DESCRIPTION
## Summary
- Use `config.home.homeDirectory` and `config.home.username` in home-manager modules (git.nix, nushell.nix, claude.nix)
- Use `config.system.primaryUser` in nix-darwin module (screen_capture.nix)
- Eliminates hardcoded `/Users/naitokosuke` across 4 files

## Test plan
- [ ] Run `darwin-rebuild switch --flake .#Mac-big` and verify:
  - Screenshot location is still `~/Pictures/screen_shots/`
  - `git config ghq.root` returns correct path
  - Nushell default directory works on launch
  - Claude Code rules/skills symlinks point to correct paths

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)