### PR TITLE
Add comment explaining why programs.zsh.enable is false

### DIFF
--- a/hosts/common/nix.nix
+++ b/hosts/common/nix.nix
@@ -4,6 +4,10 @@
   ...
 }:
 {
+  # Disable nix-darwin's /etc/zshrc management.
+  # Zsh configuration is handled entirely by home-manager.
+  # Nushell is the primary interactive shell; Zsh serves as login shell
+  # for IDE integrations and SSH sessions.
   programs.zsh.enable = false;
 
   nix.package = pkgs.lix;


### PR DESCRIPTION
## Summary
- Add explanatory comment to `programs.zsh.enable = false` in `hosts/common/nix.nix`
- Clarifies that nix-darwin's `/etc/zshrc` management is disabled because Zsh is configured by home-manager, and Nushell is the primary interactive shell

## Test plan
- [ ] No functional changes; verify `nix fmt` passes

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)