### PR TITLE
Unify host default.nix files to function-style modules

### DIFF
--- a/hosts/Mac-big/default.nix
+++ b/hosts/Mac-big/default.nix
@@ -1,2 +1,4 @@
+{ ... }:
 {
+  # No host-specific settings for Mac mini
 }

--- a/hosts/Macbook-heavy/default.nix
+++ b/hosts/Macbook-heavy/default.nix
@@ -1,3 +1,4 @@
+{ ... }:
 {
   security.pam.services.sudo_local.touchIdAuth = true;
 }


### PR DESCRIPTION
## Summary
- Convert `hosts/Mac-big/default.nix` from `{ }` to `{ ... }: { }`
- Convert `hosts/Macbook-heavy/default.nix` from `{ ... }` to `{ ... }: { ... }`
- Both files now use the standard nix-darwin function-style module pattern

## Test plan
- [ ] Run `darwin-rebuild switch --flake .#Mac-big` and verify no regressions

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)