### PR TITLE
Disable enableRosetta and remove Taps symlink workaround

### DIFF
--- a/hosts/common/homebrew.nix
+++ b/hosts/common/homebrew.nix
@@ -1,23 +1,5 @@
 { config, pkgs, ... }:
 {
-  # Remove Taps symlink and create writable directory before homebrew activation
-  # extraActivation runs before homebrew in nix-darwin's hardcoded order
-  system.activationScripts.extraActivation.text = ''
-    for TAPS_DIR in "/opt/homebrew/Library/Taps" "/usr/local/Homebrew/Library/Taps"; do
-      # Remove symlink to Nix store if exists
-      if [ -L "$TAPS_DIR" ]; then
-        rm "$TAPS_DIR"
-        mkdir -p "$TAPS_DIR"
-        chown naitokosuke:admin "$TAPS_DIR"
-      fi
-      # Fix permissions if directory exists
-      if [ -d "$TAPS_DIR" ]; then
-        chown naitokosuke:admin "$TAPS_DIR"
-        chmod 755 "$TAPS_DIR"
-      fi
-    done
-  '';
-
   homebrew = {
     enable = true;
 

--- a/hosts/common/nix-homebrew.nix
+++ b/hosts/common/nix-homebrew.nix
@@ -5,7 +5,7 @@
 {
   nix-homebrew = {
     enable = true;
-    enableRosetta = true;
+    enableRosetta = false;
     user = "naitokosuke";
     autoMigrate = true;
     taps = {


### PR DESCRIPTION
## Summary

- Set `enableRosetta = false` (no Intel Homebrew packages installed via Rosetta 2)
- Remove the Taps symlink workaround activation script from `homebrew.nix`

## Background

With `enableRosetta = true`, nix-homebrew also set up a Homebrew prefix at `/usr/local/Homebrew`. On the Rosetta side, the entire `Taps` directory became a symlink to the Nix store, causing `mkdir: /usr/local/Homebrew/Library/Taps: No such file or directory` during `darwin-rebuild switch`.

With `mutableTaps = true`, the ARM64 prefix (`/opt/homebrew`) correctly keeps `Taps/` as a real directory with only individual taps symlinked. The issue only affected the Rosetta prefix.

Since no packages are installed via Rosetta Homebrew (`/usr/local/bin/brew list` returns empty), `enableRosetta` is disabled. This also makes the activation script workaround unnecessary, so it is removed.

## Test plan

- [ ] `darwin-rebuild switch --flake .#Mac-big` completes without errors

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)