### PR TITLE
Use programs.ghostty module instead of home.file

### DIFF
--- a/home/naitokosuke/ghostty.nix
+++ b/home/naitokosuke/ghostty.nix
@@ -1,19 +1,26 @@
 { pkgs, ... }:
 
 {
-  home.file.".config/ghostty/config".text = ''
-    # Use Nushell as the shell
-    command = ${pkgs.nushell}/bin/nu --login
+  programs.ghostty = {
+    enable = true;
+    # Ghostty is installed via Homebrew Cask, so don't install via Nix
+    package = null;
+    settings = {
+      # Use Nushell as the shell
+      command = "${pkgs.nushell}/bin/nu --login";
 
-    theme = "Catppuccin Mocha"
-    font-feature = -calt
-    font-feature = -dlig
+      theme = "Catppuccin Mocha";
+      font-feature = [
+        "-calt"
+        "-dlig"
+      ];
 
-    # Shift+Enter to insert newline
-    # Ghostty implements fixterms, which sends escape sequence [27;2;13~ for Shift+Enter.
-    # This breaks multi-line input in Claude Code CLI (which expects a newline character).
-    # Rebind Shift+Enter to send \n directly, matching iTerm2's behavior.
-    # See: https://github.com/ghostty-org/ghostty/discussions/7780
-    keybind = shift+enter=text:\n
-  '';
+      # Shift+Enter to insert newline
+      # Ghostty implements fixterms, which sends escape sequence [27;2;13~ for Shift+Enter.
+      # This breaks multi-line input in Claude Code CLI (which expects a newline character).
+      # Rebind Shift+Enter to send \n directly, matching iTerm2's behavior.
+      # See: https://github.com/ghostty-org/ghostty/discussions/7780
+      keybind = "shift+enter=text:\\n";
+    };
+  };
 }


### PR DESCRIPTION
## Summary

- Migrate Ghostty config from raw `home.file` text to structured `programs.ghostty` module
- Keep Homebrew Cask installation with `package = null`
- Settings get type checking and structured attribute set

## Test plan

- [ ] Run `darwin-rebuild switch --flake .#Mac-big`
- [ ] Verify `~/.config/ghostty/config` is generated correctly
- [ ] Confirm Ghostty launches with correct settings (theme, font-feature, keybind)

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)