### PR TITLE
Clean up unused pkgs definition in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,8 +52,6 @@
       system = "aarch64-darwin";
       pkgs = import nixpkgs {
         localSystem = system;
-        config.allowUnfree = true;
-        overlays = [ llm-agents.overlays.default ];
       };
 
       mkDarwinConfig =


### PR DESCRIPTION
## Summary

- Remove `config.allowUnfree = true` and `overlays = [ llm-agents.overlays.default ]` from the top-level `pkgs` definition
- The top-level `pkgs` is only used for the `treefmt-nix` formatter, which does not need unfree config or the llm-agents overlay
- System configurations already have their own independent nixpkgs evaluation with these settings inside `mkDarwinConfig`

Closes #234

## Test plan

- [ ] Run `nix fmt` to verify the formatter still works correctly
- [ ] Run `darwin-rebuild switch --flake .#Mac-big` to verify system builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)