### PR TITLE
Fix claude.nix activation to preserve user settings across rebuilds

### DIFF
--- a/home/naitokosuke/claude.nix
+++ b/home/naitokosuke/claude.nix
@@ -52,10 +52,10 @@
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       claude_settings="$HOME/.claude/settings.json"
       run mkdir -p "$HOME/.claude"
-      # Remove existing file (symlink or regular) before copying
-      [ -e "$claude_settings" ] && run rm -f "$claude_settings"
-      run cp ${claudeSettingsContent} "$claude_settings"
-      run chmod u+w "$claude_settings"
+      # Only remove symlinks (leftover from old home.file approach)
+      [ -L "$claude_settings" ] && run rm "$claude_settings"
+      # Only copy if file doesn't exist, preserving user changes made at runtime
+      [ ! -f "$claude_settings" ] && run cp ${claudeSettingsContent} "$claude_settings"
     '';
 
   # Serena config - create as real writable file, not symlink


### PR DESCRIPTION
## Summary

- Fix the activation script in `claude.nix` that unconditionally deleted and recreated `settings.json` on every rebuild, losing any user changes Claude Code made at runtime
- Align the claude settings activation pattern with the existing Serena config pattern: only remove symlinks (leftover from old `home.file` approach) and only copy if the file doesn't already exist

## Test plan

- [ ] Run `darwin-rebuild switch --flake .#Mac-big` and verify `~/.claude/settings.json` is created if it doesn't exist
- [ ] Modify `~/.claude/settings.json` manually, then run rebuild again and verify the manual changes are preserved
- [ ] If a symlink exists at `~/.claude/settings.json`, verify it gets removed and replaced with a fresh copy

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)