### PR TITLE
Replace fragile sed JSONC conversion with Node.js parser

### DIFF
--- a/home/naitokosuke/vscode.nix
+++ b/home/naitokosuke/vscode.nix
@@ -4,21 +4,67 @@
   ...
 }:
 let
-  # Convert JSONC to JSON by removing comments and trailing commas
-  keybindings-json = pkgs.runCommand "keybindings.json" { } ''
-    # Install jq for JSON processing
-    export PATH=${pkgs.jq}/bin:$PATH
+  # Node.js script that converts JSONC to JSON by parsing character-by-character,
+  # properly handling string boundaries, escaped quotes, and both comment styles.
+  jsonc-to-json = pkgs.writeText "jsonc-to-json.js" ''
+    const fs = require("fs");
+    const input = fs.readFileSync(process.argv[2], "utf8");
 
-    # Convert JSONC to JSON
-    # Remove comments and trailing commas, then format as valid JSON
-    cat ${inputs.vscode-settings}/keybinding.jsonc \
-      | sed 's|//.*||g' \
-      | sed 's|/\*.*\*/||g' \
-      | tr -d '\n' \
-      | sed 's/,\s*}/}/g' \
-      | sed 's/,\s*]/]/g' \
-      | jq . > $out
+    let result = "";
+    let i = 0;
+    let inString = false;
+
+    while (i < input.length) {
+      const ch = input[i];
+
+      if (inString) {
+        result += ch;
+        if (ch === "\\" ) {
+          // Escaped character: copy next char as-is
+          i++;
+          if (i < input.length) result += input[i];
+        } else if (ch === '"') {
+          inString = false;
+        }
+      } else {
+        if (ch === '"') {
+          inString = true;
+          result += ch;
+        } else if (ch === '/' && i + 1 < input.length && input[i + 1] === '/') {
+          // Single-line comment: skip until end of line
+          i += 2;
+          while (i < input.length && input[i] !== '\n') i++;
+          continue; // don't increment i again at the end
+        } else if (ch === '/' && i + 1 < input.length && input[i + 1] === '*') {
+          // Multi-line comment: skip until */
+          i += 2;
+          while (i < input.length && !(input[i] === '*' && i + 1 < input.length && input[i + 1] === '/')) i++;
+          i += 2; // skip the closing */
+          continue;
+        } else {
+          result += ch;
+        }
+      }
+      i++;
+    }
+
+    // Remove trailing commas before } or ]
+    result = result.replace(/,(\s*[}\]])/g, "$1");
+
+    // Validate and pretty-print
+    const parsed = JSON.parse(result);
+    fs.writeFileSync(process.argv[3], JSON.stringify(parsed, null, 2) + "\n");
   '';
+
+  # Convert JSONC to JSON using the Node.js parser
+  keybindings-json = pkgs.stdenvNoCC.mkDerivation {
+    name = "keybindings.json";
+    nativeBuildInputs = [ pkgs.nodejs-slim ];
+    dontUnpack = true;
+    buildCommand = ''
+      node ${jsonc-to-json} ${inputs.vscode-settings}/keybinding.jsonc $out
+    '';
+  };
 in
 {
   # VSCode settings configuration


### PR DESCRIPTION
## Summary

- Replace the sed-based JSONC-to-JSON pipeline in `vscode.nix` with a character-by-character Node.js parser
- The new parser properly tracks string boundaries (respecting escaped quotes), handles both single-line (`//`) and multi-line (`/* */`) comments only outside strings, removes trailing commas, and validates output with `JSON.parse()`
- Uses `pkgs.nodejs-slim` and `pkgs.stdenvNoCC.mkDerivation` for the derivation

## Test plan

- [ ] Run `darwin-rebuild switch --flake .#Mac-big` to verify the derivation builds successfully
- [ ] Check that `~/Library/Application Support/Code/User/keybindings.json` is valid JSON
- [ ] Verify keybindings containing URLs with `//` are preserved correctly

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)