### PR TITLE
Add VS Code nix-ide setup and nixd package

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,11 @@
-{}
+{
+  "nix.enableLanguageServer": true,
+  "nix.serverPath": "nixd",
+  "nix.serverSettings": {
+    "nixd": {
+      "formatting": {
+        "command": ["nixfmt"]
+      }
+    }
+  }
+}

--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1771700389,
-        "narHash": "sha256-vZeu+YsWFV3MoM5WHZ5+rgE4qJBC9Ji4i++/B1m3bEQ=",
+        "lastModified": 1771701906,
+        "narHash": "sha256-Jtotr2d2f1J0Am3d+T1V06UnqTw8IMGSRi9sHVyERlg=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "e1c954189b01c41d7fa52bdecc1a25c27d3ebff5",
+        "rev": "1d52e68f5457160fa2aacbd717e7c6b3e7d8329d",
         "type": "github"
       },
       "original": {

--- a/hosts/common/packages.nix
+++ b/hosts/common/packages.nix
@@ -17,6 +17,7 @@
     git
     gomi
     ni
+    nixd
     nodejs_24
     pnpm
     ripgrep


### PR DESCRIPTION
## Summary

- Configure `.vscode/settings.json` with nix-ide settings (nixd LSP + nixfmt formatter)
- Add `nixd` to system packages in `hosts/common/packages.nix`

Closes #248

## Test plan

- [ ] Run `darwin-rebuild switch --flake .#Mac-big` to apply changes
- [ ] Open VS Code in the project and verify nix-ide works with nixd

🤖 Generated with [Claude Code](https://claude.com/claude-code)