### PR TITLE
Remove unused arguments in nix modules

### DIFF
--- a/home/naitokosuke/atuin.nix
+++ b/home/naitokosuke/atuin.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ ... }:
 {
   programs.atuin = {
     enable = true;

--- a/home/naitokosuke/direnv.nix
+++ b/home/naitokosuke/direnv.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ ... }:
 
 {
   programs.direnv = {

--- a/home/naitokosuke/octorus.nix
+++ b/home/naitokosuke/octorus.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ ... }:
 {
   xdg.configFile = {
     "octorus/config.toml".text = ''

--- a/home/naitokosuke/starship.nix
+++ b/home/naitokosuke/starship.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ ... }:
 
 {
   programs.starship = {

--- a/hosts/common/gomi.nix
+++ b/hosts/common/gomi.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ ... }:
 {
   launchd.user.agents.gomi-prune = {
     serviceConfig = {

--- a/hosts/common/homebrew.nix
+++ b/hosts/common/homebrew.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ ... }:
 {
   homebrew = {
     enable = true;


### PR DESCRIPTION
## Summary

- nixd の警告を解消するため、未使用の `config` / `pkgs` 引数を 6 ファイルから削除

## 対象ファイル

- `home/naitokosuke/atuin.nix`
- `home/naitokosuke/direnv.nix`
- `home/naitokosuke/octorus.nix`
- `home/naitokosuke/starship.nix`
- `hosts/common/gomi.nix`
- `hosts/common/homebrew.nix`

## Test plan

- [ ] `darwin-rebuild switch --flake .#Mac-big` が正常に完了すること

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)