### PR TITLE
refactor: use json5 parser for JSONC-to-JSON conversion

### DIFF
--- a/home/naitokosuke/vscode.nix
+++ b/home/naitokosuke/vscode.nix
@@ -4,20 +4,15 @@
   ...
 }:
 let
-  # Convert JSONC to JSON by removing comments and trailing commas
-  keybindings-json = pkgs.runCommand "keybindings.json" { } ''
-    # Install jq for JSON processing
-    export PATH=${pkgs.jq}/bin:$PATH
-
-    # Convert JSONC to JSON
-    # Remove comments and trailing commas, then format as valid JSON
-    cat ${inputs.vscode-settings}/keybinding.jsonc \
-      | sed 's|//.*||g' \
-      | sed 's|/\*.*\*/||g' \
-      | tr -d '\n' \
-      | sed 's/,\s*}/}/g' \
-      | sed 's/,\s*]/]/g' \
-      | jq . > $out
+  python = pkgs.python3.withPackages (ps: [ ps.json5 ]);
+  keybindings-json = pkgs.runCommand "keybindings.json" {
+    nativeBuildInputs = [ python ];
+  } ''
+    python3 -c "
+    import json5, json
+    data = json5.load(open('${inputs.vscode-settings}/keybinding.jsonc'))
+    json.dump(data, open('$out', 'w'), indent=2)
+    "
   '';
 in
 {


### PR DESCRIPTION
## Summary

- Replace fragile sed/tr/jq pipeline with `python3-json5` for JSONC-to-JSON conversion of VSCode keybindings

The previous approach used regex-based sed to strip comments and trailing commas, which could break on `//` inside string values. `json5` properly parses JSONC format.

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)