### PR TITLE
fix: workaround direnv CGO_ENABLED build  failure on aarch64-darwin

### DIFF
--- a/home/naitokosuke/direnv.nix
+++ b/home/naitokosuke/direnv.nix
@@ -4,6 +4,7 @@
   programs.direnv = {
     enable = true;
     # FIXME: Remove this override once the fix lands in nixpkgs-unstable
+    # https://github.com/naitokosuke/dotfiles/pull/283
     # https://github.com/NixOS/nixpkgs/issues/504092
     # https://github.com/NixOS/nixpkgs/pull/502769
     package = pkgs.direnv.overrideAttrs (old: {


### PR DESCRIPTION
Closes #282

