### PR TITLE
fix: configure nixd with getFlake-based nixpkgs and options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,17 @@
   "nix.serverPath": "nixd",
   "nix.serverSettings": {
     "nixd": {
+      "nixpkgs": {
+        "expr": "import (builtins.getFlake (builtins.toString ./.)).inputs.nixpkgs { }"
+      },
+      "options": {
+        "darwin": {
+          "expr": "(builtins.head (builtins.attrValues (builtins.getFlake (builtins.toString ./.)).darwinConfigurations)).options"
+        },
+        "home-manager": {
+          "expr": "(builtins.head (builtins.attrValues (builtins.getFlake (builtins.toString ./.)).darwinConfigurations)).options.home-manager.users.type.getSubOptions []"
+        }
+      },
       "formatting": {
         "command": ["nixfmt"]
       }


### PR DESCRIPTION
Closes #303

## Summary

nixd's default `import <nixpkgs> { }` fails because `NIX_PATH` is unset in this flake-only environment, causing hover to hang on "Loading...". Switch to `builtins.getFlake`-based expressions and pick any darwinConfigurations entry via `builtins.head (builtins.attrValues ...)` to avoid hardcoding the hostname.

## Validated expressions

All three expressions were tested with `nix eval --impure --expr` before putting them in `settings.json`.

### nixpkgs

```nix
import (builtins.getFlake (builtins.toString ./.)).inputs.nixpkgs { }
```

```
$ nix eval --impure --expr '(import (builtins.getFlake (builtins.toString ./.)).inputs.nixpkgs { }).lib.version'
"26.05pre-git"
```

### options.darwin

```nix
(builtins.head (builtins.attrValues (builtins.getFlake (builtins.toString ./.)).darwinConfigurations)).options
```

```
$ nix eval --impure --expr '((builtins.head (builtins.attrValues (builtins.getFlake (builtins.toString ./.)).darwinConfigurations)).options) ? system'
true
```

### options.home-manager

```nix
(builtins.head (builtins.attrValues (builtins.getFlake (builtins.toString ./.)).darwinConfigurations)).options.home-manager.users.type.getSubOptions []
```

```
$ nix eval --impure --expr '((builtins.head (builtins.attrValues (builtins.getFlake (builtins.toString ./.)).darwinConfigurations)).options.home-manager.users.type.getSubOptions []) ? home'
true
```

## Test plan

* [ ] Reload VS Code window, hover over a nixpkgs attribute, verify docs appear instead of "Loading..."
* [ ] Hover over a darwin option (e.g. `system.stateVersion`), verify options docs appear
* [ ] Hover over a home-manager option, verify options docs appear