### PR TITLE
chore: remove unused Rosetta 2 activation script

### DIFF
--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -12,7 +12,6 @@
     ./menubar.nix
     ./nix.nix
     ./packages.nix
-    ./rosetta.nix
     ./scroll.nix
     ./screen_capture.nix
   ];

--- a/hosts/common/rosetta.nix
+++ b/hosts/common/rosetta.nix
@@ -1,9 +1,0 @@
-{ ... }:
-
-{
-  # Install Rosetta 2 for Intel binary compatibility on Apple Silicon
-  # Reference: https://github.com/LnL7/nix-darwin/issues/786
-  system.activationScripts.extraActivation.text = ''
-    softwareupdate --install-rosetta --agree-to-license || true
-  '';
-}


### PR DESCRIPTION
## Summary

* Removes `hosts/common/rosetta.nix` and its import from `hosts/common/default.nix`. The activation script ran `softwareupdate --install-rosetta --agree-to-license` on every rebuild but nothing in this configuration requires Intel emulation.

## Investigation

* `hosts/common/packages.nix`: all packages (bun, deno, nodejs_24, pnpm, claude-code, devbox, devenv, fd, fzf, gh, ghq, git, gomi, ni, nixd, oxfmt, ripgrep, rustup, sd, tree, uv, vim, plus the flake inputs `vize` / `octorus` / `vp`) resolve natively on `aarch64-darwin`.
* `hosts/common/homebrew.nix`: all casks (`alt-tab`, `arc`, `discord`, `ghostty`, `google-chrome`, `obsidian`, `portkiller`, `raycast`, `scroll-reverser`, `visual-studio-code`) are Universal / Apple Silicon native, and `nix-homebrew.enableRosetta = false` is already set.
* Repo-wide grep for `rosetta` / `x86_64-darwin` / `intel` turns up no hidden references outside the file being removed and the `enableRosetta = false` line.
* Host modules (`Mac-big`, `Macbook-heavy`) and the `home/naitokosuke` modules (incl. `playwright.nix`) have no Intel-only tooling. Playwright's CLI runs natively on ARM.

## Verification

* `nix eval .#darwinConfigurations.Mac-big.config.system.activationScripts.extraActivation.text` succeeds and returns `""` (the Rosetta script was the only contributor to this attribute).

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)