### PR TITLE
feat: add custom spinner verbs to Claude Code settings

### DIFF
--- a/home/naitokosuke/claude.nix
+++ b/home/naitokosuke/claude.nix
@@ -36,6 +36,16 @@ in
         preferredNotifChannel = "auto";
         shiftEnterKeyBindingInstalled = true;
         editorMode = "normal";
+        spinnerVerbs = {
+          mode = "replace";
+          verbs = [
+            "考え中"
+            "深く考え中"
+            "実装中"
+            "リファクタリング中"
+            "調査中"
+          ];
+        };
         hasUsedBackslashReturn = true;
         autoCompactEnabled = true;
         diffTool = "auto";


### PR DESCRIPTION
## Summary

* Add `spinnerVerbs` to the generated `~/.claude/settings.json` with `mode = "replace"` and a set of Japanese verbs that reflect typical work states.

Closes #194

## Test plan

* [x] `nix eval .#darwinConfigurations.Mac-big.config.home-manager.users.naitokosuke.home.activation.claudeSettings --show-trace` succeeds.
* [ ] After `darwin-rebuild switch`, `~/.claude/settings.json` contains the new `spinnerVerbs` block and Claude Code displays one of the custom verbs while thinking.

Generated with Claude Code