### PR TITLE
feat: adopt gwq for git worktree management

### DIFF
--- a/home/naitokosuke/gwq.nix
+++ b/home/naitokosuke/gwq.nix
@@ -1,0 +1,19 @@
+# gwq configuration
+#
+# gwq is a git worktree management tool, designed as the worktree counterpart to ghq.
+# https://github.com/d-kuro/gwq
+{
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  xdg.configFile."gwq/config.toml".source = tomlFormat.generate "gwq-config.toml" {
+    worktree.basedir = "${config.home.homeDirectory}/src";
+    naming.template = "{{.Host}}/{{.Owner}}/{{.Repository}}={{.Branch}}";
+  };
+}

--- a/home/naitokosuke/home.nix
+++ b/home/naitokosuke/home.nix
@@ -11,6 +11,7 @@
     ./gh.nix
     ./ghostty.nix
     ./git.nix
+    ./gwq.nix
     ./octorus.nix
     ./playwright.nix
     ./shell

--- a/hosts/common/packages.nix
+++ b/hosts/common/packages.nix
@@ -4,6 +4,25 @@
   ...
 }:
 
+let
+  # Not available in nixpkgs, so we build from source
+  gwq = pkgs.buildGoModule rec {
+    pname = "gwq";
+    version = "0.0.19";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "d-kuro";
+      repo = "gwq";
+      rev = "v${version}";
+      hash = "sha256-2uE04frxfvQBlrOg5d0hPzGE9sbpzxHEiCeJX1ilG2M=";
+    };
+
+    vendorHash = "sha256-4K01Xf1EXl/NVX1loQ76l1bW8QglBAQdvlZSo7J4NPI=";
+
+    # Upstream tests require git in PATH and a writable HOME — skip in the Nix sandbox
+    doCheck = false;
+  };
+in
 {
   environment.systemPackages = with pkgs; [
     bun
@@ -17,6 +36,7 @@
     ghq
     git
     gomi
+    gwq
     ni
     nixd
     nodejs_24


### PR DESCRIPTION
## Summary

Adopt [d-kuro/gwq](https://github.com/d-kuro/gwq) as the worktree counterpart to `ghq`, enabling parallel branch work and concurrent Claude Code agent sessions isolated per worktree.

## Changes

* `hosts/common/packages.nix`: inline `buildGoModule` for `gwq` v0.0.19 (not in nixpkgs). Tests are skipped (`doCheck = false`) because upstream tests need `git` in PATH and a writable `$HOME`, which the Nix sandbox lacks — upstream CI already validates them.
* `home/naitokosuke/gwq.nix` (new): manages `~/.config/gwq/config.toml` via `xdg.configFile` using `pkgs.formats.toml`.
* `home/naitokosuke/home.nix`: imports the new module.

## Generated `~/.config/gwq/config.toml`

```toml
[naming]
template = "{{.Host}}/{{.Owner}}/{{.Repository}}={{.Branch}}"

[worktree]
basedir = "/Users/naitokosuke/src"
```

## Test plan

* [x] `nix build` the gwq derivation — succeeds
* [x] `nix eval .#darwinConfigurations.Mac-big.config.home-manager.users.naitokosuke.xdg.configFile."gwq/config.toml".source` — evaluates and produces the TOML shown above
* [ ] `darwin-rebuild switch --flake .#Mac-big` on target host
* [ ] `gwq add -i` / `gwq cd` works after activation

Closes #306