### PR TITLE
fix: point skills symlink to .claude/skills subdirectory

### DIFF
--- a/home/naitokosuke/claude.nix
+++ b/home/naitokosuke/claude.nix
@@ -100,5 +100,5 @@ in
 
   # Claude Code skills - symlink to skill-skill-skill repository
   home.file.".claude/skills".source =
-    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/github.com/${config.home.username}/skill-skill-skill";
+    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/github.com/${config.home.username}/skill-skill-skill/.claude/skills";
 }


### PR DESCRIPTION
## Summary

* `home/naitokosuke/claude.nix`: change the `~/.claude/skills` symlink target from the `skill-skill-skill` repository root to its `.claude/skills/` subdirectory, where the actual skill files live.

## Verification

```
$ nix build --no-link --print-out-paths \
    .#darwinConfigurations.Mac-big.config.home-manager.users.naitokosuke.home.file.\".claude/skills\".source \
  | xargs readlink
/Users/naitokosuke/src/github.com/naitokosuke/skill-skill-skill/.claude/skills
```

After `darwin-rebuild switch --flake .#Mac-big`, `ls ~/.claude/skills/` should show `fix-bug.md` and `markdown-writing.md` directly.

## Test plan

- [x] `nix eval` / `nix build` resolves the symlink target to `…/skill-skill-skill/.claude/skills`
- [ ] `darwin-rebuild switch --flake .#Mac-big` on target host
- [ ] `ls ~/.claude/skills/` lists skill files at the top level
- [ ] Claude Code picks up `fix-bug` / `markdown-writing` skills

Closes #311