### PR TITLE
fix(flake): drop obsolete brew-src 5.1.10 pin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,16 +28,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778146321,
-        "narHash": "sha256-HeBwuJmuBioZHyZqDOcf7W/xsMFupSD583v6I5Cl7a8=",
+        "lastModified": 1781226006,
+        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "af835384ac574f76025adb38b292b04cecee1f1f",
+        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.10",
+        "ref": "6.0.1",
         "repo": "brew",
         "type": "github"
       }
@@ -199,9 +199,7 @@
     },
     "nix-homebrew": {
       "inputs": {
-        "brew-src": [
-          "brew-src"
-        ]
+        "brew-src": "brew-src"
       },
       "locked": {
         "lastModified": 1781389246,
@@ -317,7 +315,6 @@
     },
     "root": {
       "inputs": {
-        "brew-src": "brew-src",
         "home-manager": "home-manager",
         "homebrew-cask": "homebrew-cask",
         "llm-agents": "llm-agents",

--- a/flake.nix
+++ b/flake.nix
@@ -14,15 +14,6 @@
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
 
     nix-homebrew.url = "github:zhaofengli/nix-homebrew";
-    nix-homebrew.inputs.brew-src.follows = "brew-src";
-
-    # Override brew-src to 5.1.10 to pick up the upstream fix for the
-    # `process_depends_on` crash on `depends_on: { macos: {} }` casks.
-    # https://github.com/zhaofengli/nix-homebrew/issues/138
-    brew-src = {
-      url = "github:Homebrew/brew/5.1.10";
-      flake = false;
-    };
 
     homebrew-cask = {
       url = "github:homebrew/homebrew-cask";


### PR DESCRIPTION
## 概要

`flake.nix` の `brew-src` の `5.1.10` への override を削除し、nix-homebrew のデフォルト brew-src（現状 **6.0.1**）に追従させる。

Closes #336

## 背景

この override は、nix-homebrew のデフォルト brew-src が 5.1.7 固定で `depends_on: { macos: {} }` を持つ cask 処理時に `process_depends_on` がクラッシュする問題 (zhaofengli/nix-homebrew#138) を回避するため、修正入りの 5.1.10 へ**前方 pin** したものだった。

現在は:

- zhaofengli/nix-homebrew#138 は **Closed**（上流修正は 2026-05-07 マージ済み）
- nix-homebrew main のデフォルト brew-src は **6.0.1** まで進み、当該修正を含む

ため、override は役目を終えており、残すと逆に **6.0.1 → 5.1.10 の意図的ダウングレード**になっていた。

## 変更内容

- `flake.nix` から `brew-src` の override と `nix-homebrew.inputs.brew-src.follows` を削除
- `nix flake lock` 更新（top-level `brew-src` input 削除、nix-homebrew/brew-src が 6.0.1 を解決）

## 動作確認

- `nix build .#darwinConfigurations.Macbook-heavy.system` → **成功**（`brew-6.0.1-patched` がビルドされることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)