### PR TITLE
fix(homebrew): trust productdevbook/tap for Homebrew 6.0 tap trust

### DIFF
--- a/hosts/common/homebrew.nix
+++ b/hosts/common/homebrew.nix
@@ -20,7 +20,10 @@
     enable = true;
 
     taps = [
-      "productdevbook/tap"
+      {
+        name = "productdevbook/tap";
+        trusted = true;
+      }
     ];
 
     onActivation = {


### PR DESCRIPTION
## 概要

`productdevbook/tap` を `trusted = true` にして、Homebrew 6.0 の tap trust によるスキップ警告を解消する。

Closes #338

## 事象

```
Warning: Skipping productdevbook/tap because it is not trusted. Run `brew trust productdevbook/tap` to trust it.
```

Homebrew 6.0.0 で `HOMEBREW_REQUIRE_TAP_TRUST` がデフォルト有効になり、非公式 tap は明示信頼が必要になった。nix-darwin の tap は `trusted` デフォルト `false` のため未信頼扱いとなり、`portkiller` が処理されない。

## 変更

`hosts/common/homebrew.nix` の tap を attrset 化し `trusted = true` を付与。

## 動作確認

- `nix build .#darwinConfigurations.Macbook-heavy.system` 成功
- 生成 Brewfile に `tap "productdevbook/tap", trusted: true` が出力されることを確認
- brew 6.0.1 で `trusted: true` 構文が機能（Homebrew/brew#22668 修正済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)