### PR TITLE
feat: migrate vize, octorus, and vite-plus (vp) to nvfetcher-managed pkgs

### DIFF
--- a/.github/workflows/nvfetcher.yml
+++ b/.github/workflows/nvfetcher.yml
@@ -3,8 +3,8 @@ name: nvfetcher
 on:
   workflow_dispatch:
   schedule:
-    # Weekly on Monday 09:00 JST
-    - cron: "0 0 * * 1"
+    # Daily at 08:00 JST
+    - cron: "0 23 * * *"
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Tools not available in nixpkgs (e.g. [`ax`](https://github.com/yusukebe/ax),
 [`vite-plus`](https://github.com/voidzero-dev/vite-plus) (`vp`))
 are packaged in [`pkgs/`](pkgs/),
 with versions and hashes tracked by [nvfetcher](https://github.com/berberman/nvfetcher) via
-[`nvfetcher.toml`](nvfetcher.toml). A weekly GitHub Actions workflow regenerates the pins and opens an update PR.
+[`nvfetcher.toml`](nvfetcher.toml). A daily GitHub Actions workflow (08:00 JST) regenerates the pins and opens an update PR.
 
 Once the official nixpkgs packaging of vite-plus ([NixOS/nixpkgs#533925](https://github.com/NixOS/nixpkgs/pull/533925))
 lands, `pkgs/vite-plus.nix` will be replaced by `pkgs.vite-plus` (see the TODO in that file).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An interactive, VS Code-flavoured walkthrough of this repository is published at
 ├── flake.nix          # Entry point: flake inputs and darwinConfigurations
 ├── nvfetcher.toml     # Version tracker for CLI tools not in nixpkgs (nvfetcher)
 ├── _sources/          # nvfetcher-generated pins (version + URL + hash) — never edit by hand
-├── pkgs/              # Custom package derivations (ax, …) reading from _sources/
+├── pkgs/              # Custom package derivations (ax, octorus, vize, …) reading from _sources/
 ├── modules/
 │   └── naitokosuke/   # Shared module: personal constants (username, email, …)
 │                      #   exposed as `config.naitokosuke.*` to both nix-darwin and home-manager
@@ -67,9 +67,15 @@ Each `default.nix` aggregates the modules in its directory — see them for the 
 
 Managed via nixpkgs. See [`hosts/common/packages.nix`](hosts/common/packages.nix).
 
-Tools not available in nixpkgs (e.g. [`ax`](https://github.com/yusukebe/ax)) are packaged in [`pkgs/`](pkgs/),
+Tools not available in nixpkgs (e.g. [`ax`](https://github.com/yusukebe/ax),
+[`vize`](https://github.com/ubugeeei-prod/vize), [`octorus`](https://github.com/ushironoko/octorus))
+are packaged in [`pkgs/`](pkgs/),
 with versions and hashes tracked by [nvfetcher](https://github.com/berberman/nvfetcher) via
 [`nvfetcher.toml`](nvfetcher.toml). A weekly GitHub Actions workflow regenerates the pins and opens an update PR.
+
+`vp` ([vite-plus](https://github.com/voidzero-dev/vite-plus)) is the exception: it stays on the
+[vp-nix](https://github.com/naitokosuke/vp-nix) flake input until the official nixpkgs packaging
+([NixOS/nixpkgs#533925](https://github.com/NixOS/nixpkgs/pull/533925)) lands.
 
 ### GUI Apps
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An interactive, VS Code-flavoured walkthrough of this repository is published at
 ├── flake.nix          # Entry point: flake inputs and darwinConfigurations
 ├── nvfetcher.toml     # Version tracker for CLI tools not in nixpkgs (nvfetcher)
 ├── _sources/          # nvfetcher-generated pins (version + URL + hash) — never edit by hand
-├── pkgs/              # Custom package derivations (ax, octorus, vize, …) reading from _sources/
+├── pkgs/              # Custom package derivations (ax, octorus, vite-plus, vize, …) reading from _sources/
 ├── modules/
 │   └── naitokosuke/   # Shared module: personal constants (username, email, …)
 │                      #   exposed as `config.naitokosuke.*` to both nix-darwin and home-manager
@@ -68,14 +68,14 @@ Each `default.nix` aggregates the modules in its directory — see them for the 
 Managed via nixpkgs. See [`hosts/common/packages.nix`](hosts/common/packages.nix).
 
 Tools not available in nixpkgs (e.g. [`ax`](https://github.com/yusukebe/ax),
-[`vize`](https://github.com/ubugeeei-prod/vize), [`octorus`](https://github.com/ushironoko/octorus))
+[`vize`](https://github.com/ubugeeei-prod/vize), [`octorus`](https://github.com/ushironoko/octorus),
+[`vite-plus`](https://github.com/voidzero-dev/vite-plus) (`vp`))
 are packaged in [`pkgs/`](pkgs/),
 with versions and hashes tracked by [nvfetcher](https://github.com/berberman/nvfetcher) via
 [`nvfetcher.toml`](nvfetcher.toml). A weekly GitHub Actions workflow regenerates the pins and opens an update PR.
 
-`vp` ([vite-plus](https://github.com/voidzero-dev/vite-plus)) is the exception: it stays on the
-[vp-nix](https://github.com/naitokosuke/vp-nix) flake input until the official nixpkgs packaging
-([NixOS/nixpkgs#533925](https://github.com/NixOS/nixpkgs/pull/533925)) lands.
+Once the official nixpkgs packaging of vite-plus ([NixOS/nixpkgs#533925](https://github.com/NixOS/nixpkgs/pull/533925))
+lands, `pkgs/vite-plus.nix` will be replaced by `pkgs.vite-plus` (see the TODO in that file).
 
 ### GUI Apps
 

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -29,6 +29,21 @@
         },
         "version": "0.6.7"
     },
+    "vite-plus-darwin-arm64": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "vite-plus-darwin-arm64",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-2m07OPIdNyIhrg/jsI4dTRePIkPHlHmim+FzLXZm0eo=",
+            "type": "url",
+            "url": "https://github.com/voidzero-dev/vite-plus/releases/download/v0.2.6/vp-aarch64-apple-darwin.tar.gz"
+        },
+        "version": "v0.2.6"
+    },
     "vize-darwin-arm64": {
         "cargoLock": null,
         "date": null,

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -13,5 +13,35 @@
             "url": "https://github.com/yusukebe/ax/releases/download/v0.1.21/ax-darwin-arm64"
         },
         "version": "v0.1.21"
+    },
+    "octorus-darwin-arm64": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "octorus-darwin-arm64",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-fsqnB49TnsPG9waafix0ILJHjslGJEmAPc2EiJS0g+Y=",
+            "type": "url",
+            "url": "https://github.com/ushironoko/octorus/releases/download/v0.6.7/octorus-0.6.7-aarch64-apple-darwin.tar.gz"
+        },
+        "version": "0.6.7"
+    },
+    "vize-darwin-arm64": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "vize-darwin-arm64",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-UnEUAxlmJVUdqwDs6iASlOfC5WAQdH55QCYx9+i/SVQ=",
+            "type": "url",
+            "url": "https://github.com/ubugeeei-prod/vize/releases/download/v0.291.0/vize-aarch64-apple-darwin.tar.gz"
+        },
+        "version": "v0.291.0"
     }
 }

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -22,6 +22,14 @@
       sha256 = "sha256-fsqnB49TnsPG9waafix0ILJHjslGJEmAPc2EiJS0g+Y=";
     };
   };
+  vite-plus-darwin-arm64 = {
+    pname = "vite-plus-darwin-arm64";
+    version = "v0.2.6";
+    src = fetchurl {
+      url = "https://github.com/voidzero-dev/vite-plus/releases/download/v0.2.6/vp-aarch64-apple-darwin.tar.gz";
+      sha256 = "sha256-2m07OPIdNyIhrg/jsI4dTRePIkPHlHmim+FzLXZm0eo=";
+    };
+  };
   vize-darwin-arm64 = {
     pname = "vize-darwin-arm64";
     version = "v0.291.0";

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -14,4 +14,20 @@
       sha256 = "sha256-cjLX9MG8lri8nCFp7oL2JpUxxMbJQeNRIXeZoDThj6c=";
     };
   };
+  octorus-darwin-arm64 = {
+    pname = "octorus-darwin-arm64";
+    version = "0.6.7";
+    src = fetchurl {
+      url = "https://github.com/ushironoko/octorus/releases/download/v0.6.7/octorus-0.6.7-aarch64-apple-darwin.tar.gz";
+      sha256 = "sha256-fsqnB49TnsPG9waafix0ILJHjslGJEmAPc2EiJS0g+Y=";
+    };
+  };
+  vize-darwin-arm64 = {
+    pname = "vize-darwin-arm64";
+    version = "v0.291.0";
+    src = fetchurl {
+      url = "https://github.com/ubugeeei-prod/vize/releases/download/v0.291.0/vize-aarch64-apple-darwin.tar.gz";
+      sha256 = "sha256-UnEUAxlmJVUdqwDs6iASlOfC5WAQdH55QCYx9+i/SVQ=";
+    };
+  };
 }

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -37,7 +37,9 @@ words:
   - treefmt
   - ubugeeei
   - ushironoko
+  - viteplus
   - vizejs
+  - voidzero
   - yusukebe
   - zhaofengli
 ignorePaths:

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -35,6 +35,9 @@ words:
   - swipescrolldirection
   - tilesize
   - treefmt
+  - ubugeeei
+  - ushironoko
+  - vizejs
   - yusukebe
   - zhaofengli
 ignorePaths:

--- a/docs/src/explanations.ts
+++ b/docs/src/explanations.ts
@@ -40,26 +40,26 @@ export const explanations: Readonly<Record<string, Explanation>> = {
         {
           title: "Inputs",
           prose:
-            "Every upstream is pinned and `follows = nixpkgs` so the world ships one pkgs set. Personal projects (`vp`, `vscode-settings`) come in as flakes too, and a few non-flake inputs (`homebrew-cask`, `skill-skill-skill`, `nu-scripts`) are locked snapshots read at eval time. `vp` carries a TODO: once the official nixpkgs packaging (NixOS/nixpkgs#533925) lands, it moves to `pkgs.vite-plus` and the input goes away — the same exit `vize` and `octorus` already took into `./pkgs`.",
-          lines: [4, 55],
+            "Every upstream is pinned and `follows = nixpkgs` so the world ships one pkgs set. `vscode-settings` and a few non-flake inputs (`homebrew-cask`, `skill-skill-skill`, `nu-scripts`) are locked snapshots read at eval time. The personal `*-nix` flakes that used to live here (`vize`, `octorus`, `vp`) have all moved into `./pkgs` under nvfetcher tracking.",
+          lines: [4, 49],
         },
         {
           title: "mkDarwinConfig",
           prose:
             "A small helper that builds one `darwinSystem` per host. It pins `aarch64-darwin` and Nixpkgs config (`allowUnfree` plus overlays: the custom `./pkgs` set tracked by nvfetcher, and `nushell` / `direnv` overrides that disable broken sandbox tests) inside an inline module — a `{ config, ... }:` function so `system.primaryUser` derives from `config.naitokosuke.username` rather than a hardcoded literal. It loads `./modules/naitokosuke` for those constants, then stitches `hosts/common`, `hosts/<hostName>`, and `home-manager` together.",
-          lines: [78, 124],
+          lines: [72, 118],
         },
         {
           title: "Per-host configurations",
           prose:
             "`darwinConfigurations` is built by mapping the `hosts` list (defined just above) through `mkDarwinConfig` with `nixpkgs.lib.genAttrs`. Adding a new Mac is a one-line append to that list — plus a `hosts/<host>/default.nix` for the diff — with no per-host `darwinConfigurations` attribute to hand-write.",
-          lines: [127, 127],
+          lines: [121, 121],
         },
         {
           title: "Custom packages output",
           prose:
             "`packages.<system>` exposes the same `./pkgs` set that the overlay injects, so `nix build .#ax` works standalone — handy for testing a derivation without evaluating a whole darwin configuration.",
-          lines: [129, 129],
+          lines: [123, 123],
         },
       ],
     },
@@ -79,10 +79,10 @@ export const explanations: Readonly<Record<string, Explanation>> = {
           lines: [4, 6],
         },
         {
-          title: "The vize and octorus entries",
+          title: "The vize, octorus, and vite-plus entries",
           prose:
-            '`vize` and `octorus` follow the same pattern with tar.gz assets — they replaced the standalone `vize-nix` / `octorus-nix` flake repos. One wrinkle: the octorus asset name embeds the version without the tag\'s `v` prefix, so `src.prefix = "v"` strips it at the tracker level and the URL re-adds it where needed.',
-          lines: [8, 17],
+            '`vize`, `octorus`, and `vite-plus` (`vp`) follow the same pattern with tar.gz assets — they replaced the standalone `vize-nix` / `octorus-nix` / `vp-nix` flake repos. One wrinkle: the octorus asset name embeds the version without the tag\'s `v` prefix, so `src.prefix = "v"` strips it at the tracker level and the URL re-adds it where needed.',
+          lines: [8, 21],
         },
       ],
     },
@@ -164,6 +164,29 @@ export const explanations: Readonly<Record<string, Explanation>> = {
           prose:
             "The tarball unpacks into a versioned directory containing the `or` binary (yes, the CLI is called `or`, not `octorus` — hence `mainProgram`). stdenv auto-detects the single top-level directory, so no `sourceRoot` juggling is needed.",
           lines: [7, 16],
+        },
+      ],
+    },
+  },
+
+  "pkgs/vite-plus.nix": {
+    about: "vite-plus (vp) — installs the official prebuilt darwin-arm64 release binary.",
+    tags: ["packages", "cli"],
+    walkthrough: {
+      intro:
+        "The Nix equivalent of upstream's `curl | bash` installer: it installs the same prebuilt `vp-aarch64-apple-darwin.tar.gz` that the official script downloads, pinned by nvfetcher. This replaced the standalone `vp-nix` flake repo. `vp` manages its own JS toolchain at runtime (`vp install` per project), so the binary is all Nix needs to provide. The TODO on top marks the exit plan: once nixpkgs ships vite-plus (NixOS/nixpkgs#533925), this file gives way to `pkgs.vite-plus`.",
+      sections: [
+        {
+          title: "Fetch and install",
+          prose:
+            'Same shape as `vize`: the tarball is flat — just the `vp` binary — so `sourceRoot = "."` keeps the unpacker in place and `install -Dm755` drops it at `$out/bin/vp`.',
+          lines: [9, 21],
+        },
+        {
+          title: "Metadata",
+          prose:
+            '`sourceProvenance = binaryNativeCode` marks the prebuilt binary honestly, `mainProgram = "vp"` names the CLI, and `platforms` pins `aarch64-darwin` — the one asset this entry tracks.',
+          lines: [23, 31],
         },
       ],
     },
@@ -363,7 +386,7 @@ export const explanations: Readonly<Record<string, Explanation>> = {
     tags: ["cli", "packages"],
     walkthrough: {
       intro:
-        "The system CLI toolbelt. Everything here is on `$PATH` for every user and login shell. Locally-built tools live alongside nixpkgs: `gwq` (worktree-aware git helper), `darwin-rebuild-nom` (pipes `darwin-rebuild` through `nix-output-monitor`), and the nvfetcher-tracked overlay packages from `./pkgs` (`ax`, `octorus`, `vize`).",
+        "The system CLI toolbelt. Everything here is on `$PATH` for every user and login shell. Locally-built tools live alongside nixpkgs: `gwq` (worktree-aware git helper), `darwin-rebuild-nom` (pipes `darwin-rebuild` through `nix-output-monitor`), and the nvfetcher-tracked overlay packages from `./pkgs` (`ax`, `octorus`, `vite-plus`, `vize`).",
       sections: [
         {
           title: "gwq, built from source",
@@ -380,7 +403,7 @@ export const explanations: Readonly<Record<string, Explanation>> = {
         {
           title: "The CLI toolbelt",
           prose:
-            "Daily drivers: `gh`, `ghq`, `git`, `fd`, `fzf`, `ripgrep`, `sd`, `bun`, `pnpm`, `nodejs_24`. Nix workflow tools: `nixd`, `devenv`, `nix-output-monitor`, plus the locally-built `darwin-rebuild-nom`. `ax`, `octorus`, and `vize` are the nvfetcher-tracked overlay packages from `./pkgs`, while `vp` (until nixpkgs ships vite-plus) and `herdr` are still wired in via flake inputs.",
+            "Daily drivers: `gh`, `ghq`, `git`, `fd`, `fzf`, `ripgrep`, `sd`, `bun`, `pnpm`, `nodejs_24`. Nix workflow tools: `nixd`, `devenv`, `nix-output-monitor`, plus the locally-built `darwin-rebuild-nom`. `ax`, `octorus`, `vite-plus` (`vp`), and `vize` are the nvfetcher-tracked overlay packages from `./pkgs`; only `herdr` is still wired in via a flake input.",
           lines: [38, 67],
         },
       ],

--- a/docs/src/explanations.ts
+++ b/docs/src/explanations.ts
@@ -193,11 +193,11 @@ export const explanations: Readonly<Record<string, Explanation>> = {
   },
 
   ".github/workflows/nvfetcher.yml": {
-    about: "Weekly CI — reruns nvfetcher and opens an update PR when pins change.",
+    about: "Daily CI — reruns nvfetcher and opens an update PR when pins change.",
     tags: ["ci", "automation"],
     walkthrough: {
       intro:
-        "The automation half of the nvfetcher story. Once a week (or on manual dispatch) CI reruns nvfetcher; if any tracked tool released a new version, the regenerated `_sources/` lands in an auto-created pull request instead of anyone remembering to bump versions. Requires the repo setting that lets Actions create PRs.",
+        "The automation half of the nvfetcher story. Every morning at 08:00 JST (or on manual dispatch) CI reruns nvfetcher; if any tracked tool released a new version, the regenerated `_sources/` lands in an auto-created pull request instead of anyone remembering to bump versions. Requires the repo setting that lets Actions create PRs.",
       sections: [
         {
           title: "Running nvfetcher",

--- a/docs/src/explanations.ts
+++ b/docs/src/explanations.ts
@@ -40,7 +40,7 @@ export const explanations: Readonly<Record<string, Explanation>> = {
         {
           title: "Inputs",
           prose:
-            "Every upstream is pinned and `follows = nixpkgs` so the world ships one pkgs set. Personal projects (`vize`, `octorus`, `vp`, `vscode-settings`) come in as flakes too, and a few non-flake inputs (`homebrew-cask`, `skill-skill-skill`, `nu-scripts`) are locked snapshots read at eval time.",
+            "Every upstream is pinned and `follows = nixpkgs` so the world ships one pkgs set. Personal projects (`vp`, `vscode-settings`) come in as flakes too, and a few non-flake inputs (`homebrew-cask`, `skill-skill-skill`, `nu-scripts`) are locked snapshots read at eval time. `vp` carries a TODO: once the official nixpkgs packaging (NixOS/nixpkgs#533925) lands, it moves to `pkgs.vite-plus` and the input goes away — the same exit `vize` and `octorus` already took into `./pkgs`.",
           lines: [4, 55],
         },
         {
@@ -77,6 +77,12 @@ export const explanations: Readonly<Record<string, Explanation>> = {
           prose:
             "`src.github` watches `yusukebe/ax` releases; `fetch.url` downloads the `ax-darwin-arm64` binary for that tag (`$ver` is substituted). The entry is named after the exact asset it pins, so adding another platform later is a new entry, not a rewrite.",
           lines: [4, 6],
+        },
+        {
+          title: "The vize and octorus entries",
+          prose:
+            '`vize` and `octorus` follow the same pattern with tar.gz assets — they replaced the standalone `vize-nix` / `octorus-nix` flake repos. One wrinkle: the octorus asset name embeds the version without the tag\'s `v` prefix, so `src.prefix = "v"` strips it at the tracker level and the URL re-adds it where needed.',
+          lines: [8, 17],
         },
       ],
     },
@@ -118,6 +124,46 @@ export const explanations: Readonly<Record<string, Explanation>> = {
           prose:
             "`sourceProvenance = binaryNativeCode` honestly marks this as a prebuilt binary, and `platforms` is pinned to `aarch64-darwin` — the only asset we track, and the only system this flake targets.",
           lines: [20, 29],
+        },
+      ],
+    },
+  },
+
+  "pkgs/vize.nix": {
+    about: "vize (Vue.js toolchain in Rust) — installs the prebuilt darwin-arm64 tarball.",
+    tags: ["packages", "cli"],
+    walkthrough: {
+      intro:
+        "Same story as `ax`: upstream ships prebuilt binaries, so the derivation just installs the `vize-aarch64-apple-darwin.tar.gz` asset that nvfetcher pinned. This replaced the standalone `vize-nix` flake repo — one less repository and update pipeline to maintain.",
+      sections: [
+        {
+          title: "Fetch and install",
+          prose:
+            'The tarball is flat — no top-level directory, just the `vize` binary — so `sourceRoot = "."` keeps the unpacker in place and `install -Dm755` does the rest.',
+          lines: [8, 20],
+        },
+        {
+          title: "Version self-check",
+          prose:
+            "`versionCheckHook` runs `vize --version` after install and fails the build if the output doesn't match the derivation version — a cheap guard against upstream renaming assets or shipping a mislabeled binary.",
+          lines: [22, 23],
+        },
+      ],
+    },
+  },
+
+  "pkgs/octorus.nix": {
+    about: "octorus (AI-powered PR review tool) — installs the prebuilt darwin-arm64 tarball.",
+    tags: ["packages", "cli"],
+    walkthrough: {
+      intro:
+        "This replaced the standalone `octorus-nix` flake repo — and simplified it: octorus-nix compiled the Rust workspace from source on every version bump, but upstream publishes prebuilt binaries, so this derivation just unpacks the pinned tarball. No more rustc runs during `darwin-rebuild switch`.",
+      sections: [
+        {
+          title: "Fetch and install",
+          prose:
+            "The tarball unpacks into a versioned directory containing the `or` binary (yes, the CLI is called `or`, not `octorus` — hence `mainProgram`). stdenv auto-detects the single top-level directory, so no `sourceRoot` juggling is needed.",
+          lines: [7, 16],
         },
       ],
     },
@@ -317,7 +363,7 @@ export const explanations: Readonly<Record<string, Explanation>> = {
     tags: ["cli", "packages"],
     walkthrough: {
       intro:
-        "The system CLI toolbelt. Everything here is on `$PATH` for every user and login shell. Locally-built tools live alongside nixpkgs: `gwq` (worktree-aware git helper), `darwin-rebuild-nom` (pipes `darwin-rebuild` through `nix-output-monitor`), and `ax` — which comes from the `./pkgs` overlay, version-tracked by nvfetcher.",
+        "The system CLI toolbelt. Everything here is on `$PATH` for every user and login shell. Locally-built tools live alongside nixpkgs: `gwq` (worktree-aware git helper), `darwin-rebuild-nom` (pipes `darwin-rebuild` through `nix-output-monitor`), and the nvfetcher-tracked overlay packages from `./pkgs` (`ax`, `octorus`, `vize`).",
       sections: [
         {
           title: "gwq, built from source",
@@ -334,7 +380,7 @@ export const explanations: Readonly<Record<string, Explanation>> = {
         {
           title: "The CLI toolbelt",
           prose:
-            "Daily drivers: `gh`, `ghq`, `git`, `fd`, `fzf`, `ripgrep`, `sd`, `bun`, `pnpm`, `nodejs_24`. Nix workflow tools: `nixd`, `devenv`, `nix-output-monitor`, plus the locally-built `darwin-rebuild-nom`. `ax` at the top is the nvfetcher-tracked overlay package from `./pkgs`, and personal projects (`vize`, `octorus`, `vp`, `herdr`) are wired in via flake inputs.",
+            "Daily drivers: `gh`, `ghq`, `git`, `fd`, `fzf`, `ripgrep`, `sd`, `bun`, `pnpm`, `nodejs_24`. Nix workflow tools: `nixd`, `devenv`, `nix-output-monitor`, plus the locally-built `darwin-rebuild-nom`. `ax`, `octorus`, and `vize` are the nvfetcher-tracked overlay packages from `./pkgs`, while `vp` (until nixpkgs ships vite-plus) and `herdr` are still wired in via flake inputs.",
           lines: [38, 67],
         },
       ],

--- a/flake.lock
+++ b/flake.lock
@@ -226,22 +226,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1773231277,
-        "narHash": "sha256-Xy3WEpUAbpsz8ydgvVAQAGGB/WB+8cNA5cshiL0McTI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "75690239f08f885ca9b0267580101f60d10fbe62",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nu-scripts": {
       "flake": false,
       "locked": {
@@ -271,7 +255,6 @@
         "nu-scripts": "nu-scripts",
         "skill-skill-skill": "skill-skill-skill",
         "treefmt-nix": "treefmt-nix_2",
-        "vp": "vp",
         "vscode-settings": "vscode-settings"
       }
     },
@@ -365,24 +348,6 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "vp": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1784293589,
-        "narHash": "sha256-jOEwG2dLbwpaC8VThLAhjU8VK6n8QoBvydGCJji/Mgs=",
-        "owner": "naitokosuke",
-        "repo": "vp-nix",
-        "rev": "fadcbbcadcb999e531c6cb4730e10e97616fe54a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "naitokosuke",
-        "repo": "vp-nix",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -228,38 +228,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1770537093,
-        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1773231277,
         "narHash": "sha256-Xy3WEpUAbpsz8ydgvVAQAGGB/WB+8cNA5cshiL0McTI=",
         "owner": "NixOS",
@@ -290,24 +258,6 @@
         "type": "github"
       }
     },
-    "octorus": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1784164579,
-        "narHash": "sha256-EUvQuCAHfMqG+4W3iDiqdwBJyAUZWBUwa7qUI7raVMw=",
-        "owner": "naitokosuke",
-        "repo": "octorus-nix",
-        "rev": "d89468e9c91bae0111a95fcc5e91da8eec071dac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "naitokosuke",
-        "repo": "octorus-nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "herdr": "herdr",
@@ -319,10 +269,8 @@
         "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs",
         "nu-scripts": "nu-scripts",
-        "octorus": "octorus",
         "skill-skill-skill": "skill-skill-skill",
         "treefmt-nix": "treefmt-nix_2",
-        "vize": "vize",
         "vp": "vp",
         "vscode-settings": "vscode-settings"
       }
@@ -420,27 +368,9 @@
         "type": "github"
       }
     },
-    "vize": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1783903610,
-        "narHash": "sha256-bQRaCuMHLgjB6plcp+KV0bUCZVJVMdGgtPaIKeue06M=",
-        "owner": "naitokosuke",
-        "repo": "vize-nix",
-        "rev": "446bc32e070a16114e6b17abec9cb146d7a02358",
-        "type": "github"
-      },
-      "original": {
-        "owner": "naitokosuke",
-        "repo": "vize-nix",
-        "type": "github"
-      }
-    },
     "vp": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1784293589,

--- a/flake.nix
+++ b/flake.nix
@@ -36,12 +36,6 @@
     herdr.url = "github:ogulcancelik/herdr";
     herdr.inputs.nixpkgs.follows = "nixpkgs";
 
-    # TODO: 公式の nixpkgs 対応(NixOS/nixpkgs#533925)が merge されたら
-    # pkgs.vite-plus に乗り換えてこの input と vp-nix を廃止する
-    # (nixpkgs 版は from-source ビルドで fspy が stub 化されているため、
-    # 縮退が解消されているかを確認してから乗り換えること)
-    vp.url = "github:naitokosuke/vp-nix";
-
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs";
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,10 +36,10 @@
     herdr.url = "github:ogulcancelik/herdr";
     herdr.inputs.nixpkgs.follows = "nixpkgs";
 
-    vize.url = "github:naitokosuke/vize-nix";
-
-    octorus.url = "github:naitokosuke/octorus-nix";
-
+    # TODO: 公式の nixpkgs 対応(NixOS/nixpkgs#533925)が merge されたら
+    # pkgs.vite-plus に乗り換えてこの input と vp-nix を廃止する
+    # (nixpkgs 版は from-source ビルドで fspy が stub 化されているため、
+    # 縮退が解消されているかを確認してから乗り換えること)
     vp.url = "github:naitokosuke/vp-nix";
 
     llm-agents.url = "github:numtide/llm-agents.nix";

--- a/hosts/common/packages.nix
+++ b/hosts/common/packages.nix
@@ -62,7 +62,7 @@ in
     tree
     uv
     vim
+    vite-plus
     vize
-    inputs.vp.packages.${pkgs.stdenv.hostPlatform.system}.default
   ];
 }

--- a/hosts/common/packages.nix
+++ b/hosts/common/packages.nix
@@ -53,6 +53,7 @@ in
     nixd
     nix-output-monitor
     nodejs_24
+    octorus
     oxfmt
     pnpm
     ripgrep
@@ -61,8 +62,7 @@ in
     tree
     uv
     vim
-    inputs.vize.packages.${pkgs.stdenv.hostPlatform.system}.default
-    inputs.octorus.packages.${pkgs.stdenv.hostPlatform.system}.default
+    vize
     inputs.vp.packages.${pkgs.stdenv.hostPlatform.system}.default
   ];
 }

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -4,3 +4,14 @@
 [ax-darwin-arm64]
 src.github = "yusukebe/ax"
 fetch.url = "https://github.com/yusukebe/ax/releases/download/$ver/ax-darwin-arm64"
+
+[vize-darwin-arm64]
+src.github = "ubugeeei-prod/vize"
+fetch.url = "https://github.com/ubugeeei-prod/vize/releases/download/$ver/vize-aarch64-apple-darwin.tar.gz"
+
+# The asset name embeds the version without the "v" tag prefix, so strip it
+# here instead of in the derivation.
+[octorus-darwin-arm64]
+src.github = "ushironoko/octorus"
+src.prefix = "v"
+fetch.url = "https://github.com/ushironoko/octorus/releases/download/v$ver/octorus-$ver-aarch64-apple-darwin.tar.gz"

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -15,3 +15,7 @@ fetch.url = "https://github.com/ubugeeei-prod/vize/releases/download/$ver/vize-a
 src.github = "ushironoko/octorus"
 src.prefix = "v"
 fetch.url = "https://github.com/ushironoko/octorus/releases/download/v$ver/octorus-$ver-aarch64-apple-darwin.tar.gz"
+
+[vite-plus-darwin-arm64]
+src.github = "voidzero-dev/vite-plus"
+fetch.url = "https://github.com/voidzero-dev/vite-plus/releases/download/$ver/vp-aarch64-apple-darwin.tar.gz"

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,5 +7,6 @@ in
 {
   ax = pkgs.callPackage ./ax.nix { inherit sources; };
   octorus = pkgs.callPackage ./octorus.nix { inherit sources; };
+  vite-plus = pkgs.callPackage ./vite-plus.nix { inherit sources; };
   vize = pkgs.callPackage ./vize.nix { inherit sources; };
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6,4 +6,6 @@ let
 in
 {
   ax = pkgs.callPackage ./ax.nix { inherit sources; };
+  octorus = pkgs.callPackage ./octorus.nix { inherit sources; };
+  vize = pkgs.callPackage ./vize.nix { inherit sources; };
 }

--- a/pkgs/octorus.nix
+++ b/pkgs/octorus.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  stdenvNoCC,
+  sources,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "octorus";
+  version = sources.octorus-darwin-arm64.version;
+  src = sources.octorus-darwin-arm64.src;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 or $out/bin/or
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "AI-powered PR review tool";
+    homepage = "https://github.com/ushironoko/octorus";
+    changelog = "https://github.com/ushironoko/octorus/releases/tag/v${sources.octorus-darwin-arm64.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "or";
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/pkgs/vite-plus.nix
+++ b/pkgs/vite-plus.nix
@@ -1,0 +1,32 @@
+# TODO: 公式の nixpkgs 対応(NixOS/nixpkgs#533925)が merge されたら
+# pkgs.vite-plus に乗り換えてこのファイルと nvfetcher エントリを削除する
+{
+  lib,
+  stdenvNoCC,
+  sources,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "vite-plus";
+  version = lib.removePrefix "v" sources.vite-plus-darwin-arm64.version;
+  src = sources.vite-plus-darwin-arm64.src;
+
+  # The tarball has no top-level directory — the `vp` binary sits at the root.
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 vp $out/bin/vp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Unified toolchain for JavaScript";
+    homepage = "https://viteplus.dev";
+    changelog = "https://github.com/voidzero-dev/vite-plus/releases/tag/${sources.vite-plus-darwin-arm64.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "vp";
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/pkgs/vize.nix
+++ b/pkgs/vize.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenvNoCC,
+  versionCheckHook,
+  sources,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "vize";
+  version = lib.removePrefix "v" sources.vize-darwin-arm64.version;
+  src = sources.vize-darwin-arm64.src;
+
+  # The tarball has no top-level directory — the `vize` binary sits at the root.
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 vize $out/bin/vize
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "High-performance Vue.js toolchain in Rust";
+    homepage = "https://vizejs.dev";
+    changelog = "https://github.com/ubugeeei-prod/vize/releases/tag/${sources.vize-darwin-arm64.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "vize";
+    platforms = [ "aarch64-darwin" ];
+  };
+}


### PR DESCRIPTION
## Summary

Implements #346: extends the nvfetcher approach from #342 (ax) to `vize`, `octorus`, and `vite-plus` (`vp`), retiring the standalone [vize-nix](https://github.com/naitokosuke/vize-nix) / [octorus-nix](https://github.com/naitokosuke/octorus-nix) / [vp-nix](https://github.com/naitokosuke/vp-nix) flake repos and their update CI. All three follow the exact ax pattern: an nvfetcher entry pinning the upstream prebuilt release asset + a thin derivation in `pkgs/`.

- **`nvfetcher.toml`** — new `vize-darwin-arm64` / `octorus-darwin-arm64` / `vite-plus-darwin-arm64` entries tracking upstream GitHub release tarballs. The octorus asset name embeds the version without the tag's `v` prefix, so `src.prefix = "v"` strips it at the tracker level
- **`pkgs/vize.nix`** — installs the prebuilt flat tarball (`sourceRoot = "."`); keeps vize-nix's `versionCheckHook` self-check
- **`pkgs/octorus.nix`** — installs the prebuilt binary (`or`). Simplification over octorus-nix, which compiled the Rust workspace from source on every bump
- **`pkgs/vite-plus.nix`** — installs the official prebuilt `vp` binary, the same asset upstream's `curl | bash` installer downloads. Simplification over vp-nix, which bundled the npm toolchain via a pnpm lockfile; `vp` manages its own JS toolchain at runtime, so the binary is all Nix needs to provide. A TODO in the file records the exit plan: switch to `pkgs.vite-plus` once the official nixpkgs packaging ([NixOS/nixpkgs#533925](https://github.com/NixOS/nixpkgs/pull/533925)) lands
- **`flake.nix`** — `vize` / `octorus` / `vp` inputs removed; no naitokosuke-managed packaging flake remains in `flake.lock`
- **`README.md` / `docs/src/explanations.ts`** — structure docs and walkthrough synced (new entries for the three `pkgs/*.nix` files)
- The nvfetcher workflow now runs daily at 08:00 JST (was weekly Monday) — all three tools ride the same update PR with no extra CI steps

After merge: archive vize-nix ([vize-nix#190](https://github.com/naitokosuke/vize-nix/issues/190)), octorus-nix ([octorus-nix#30](https://github.com/naitokosuke/octorus-nix/issues/30)), and vp-nix ([vp-nix#96](https://github.com/naitokosuke/vp-nix/issues/96)).

## Test plan

- [x] `nix build .#vize` succeeds; `./result/bin/vize --version` prints `vize 0.291.0` (versionCheckHook also runs in-build)
- [x] `nix build .#octorus` succeeds; `./result/bin/or --version` prints `or 0.6.7`
- [x] `nix build .#vite-plus` succeeds; `./result/bin/vp --version` prints `vp v0.2.6`
- [x] `darwin-rebuild switch --flake .#Macbook-heavy` applied on a real host; `vize` / `or` resolve from `/run/current-system/sw/bin`
- [x] `nix build .#darwinConfigurations.Mac-big.system --dry-run` evaluates cleanly
- [x] `nix fmt` clean; `vp check` clean in docs/; cspell clean for newly introduced words

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

