### PR TITLE
feat: provide official vpr/vpx standalone aliases for vite-plus

### DIFF
--- a/docs/src/explanations.ts
+++ b/docs/src/explanations.ts
@@ -174,19 +174,25 @@ export const explanations: Readonly<Record<string, Explanation>> = {
     tags: ["packages", "cli"],
     walkthrough: {
       intro:
-        "The Nix equivalent of upstream's `curl | bash` installer: it installs the same prebuilt `vp-aarch64-apple-darwin.tar.gz` that the official script downloads, pinned by nvfetcher. This replaced the standalone `vp-nix` flake repo. `vp` manages its own JS toolchain at runtime (`vp install` per project), so the binary is all Nix needs to provide. The TODO on top marks the exit plan: once nixpkgs ships vite-plus (NixOS/nixpkgs#533925), this file gives way to `pkgs.vite-plus`.",
+        "The Nix equivalent of upstream's `curl | bash` installer: it installs the same prebuilt `vp-aarch64-apple-darwin.tar.gz` that the official script downloads, pinned by nvfetcher, plus the `vpr` / `vpx` aliases the installer would create. This replaced the standalone `vp-nix` flake repo. `vp` manages its own JS toolchain at runtime (`vp install` per project), so the binary and its aliases are all Nix needs to provide. The TODO on top marks the exit plan: once nixpkgs ships vite-plus (NixOS/nixpkgs#533925), this file gives way to `pkgs.vite-plus`.",
       sections: [
         {
           title: "Fetch and install",
           prose:
             'Same shape as `vize`: the tarball is flat — just the `vp` binary — so `sourceRoot = "."` keeps the unpacker in place and `install -Dm755` drops it at `$out/bin/vp`.',
-          lines: [9, 21],
+          lines: [9, 19],
+        },
+        {
+          title: "The vpr/vpx aliases",
+          prose:
+            "The official installer runs `vp env setup`, which symlinks `vpr` and `vpx` next to `vp` — a multi-call binary dispatching on `argv[0]` (`vpr` → `vp run`, `vpx` → `vp dlx`). The derivation reproduces exactly those two links. The `node`/`npm`/`npx`/`corepack` shims the same step creates are deliberately omitted: they belong to the opt-out-able Node version manager and would shadow Nix-managed Node.",
+          lines: [20, 26],
         },
         {
           title: "Metadata",
           prose:
             '`sourceProvenance = binaryNativeCode` marks the prebuilt binary honestly, `mainProgram = "vp"` names the CLI, and `platforms` pins `aarch64-darwin` — the one asset this entry tracks.',
-          lines: [23, 31],
+          lines: [30, 38],
         },
       ],
     },

--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,8 @@
       flake = false;
     };
 
-    # TODO: nixpkgs の herdr は Darwin ビルド修正(NixOS/nixpkgs#536015)が
-    # nixpkgs-unstable に降りてきたら pkgs.herdr に戻してこの input を削除する
+    # TODO: Once the herdr Darwin build fix (NixOS/nixpkgs#536015) lands in
+    # nixpkgs-unstable, switch back to pkgs.herdr and delete this input.
     herdr.url = "github:ogulcancelik/herdr";
     herdr.inputs.nixpkgs.follows = "nixpkgs";
 

--- a/pkgs/vite-plus.nix
+++ b/pkgs/vite-plus.nix
@@ -1,5 +1,5 @@
-# TODO: 公式の nixpkgs 対応(NixOS/nixpkgs#533925)が merge されたら
-# pkgs.vite-plus に乗り換えてこのファイルと nvfetcher エントリを削除する
+# TODO: Once official nixpkgs support (NixOS/nixpkgs#533925) is merged,
+# switch to pkgs.vite-plus and delete this file and the nvfetcher entry.
 {
   lib,
   stdenvNoCC,
@@ -17,6 +17,13 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
     install -Dm755 vp $out/bin/vp
+    # Provide the standalone aliases the official installer creates via
+    # `vp env setup`: vp is a multi-call binary dispatching on argv[0]
+    # (vpr -> `vp run`, vpx -> `vp dlx`). The node/npm/npx/corepack shims
+    # it also creates are deliberately omitted — they belong to the
+    # opt-out-able Node version manager and would conflict with Nix-managed Node.
+    ln -s $out/bin/vp $out/bin/vpr
+    ln -s $out/bin/vp $out/bin/vpx
     runHook postInstall
   '';
 


### PR DESCRIPTION
Closes #348

## What

- `pkgs/vite-plus.nix`: add `vpr` / `vpx` symlinks to `$out/bin`, reproducing exactly what the official installer (`curl -fsSL https://vite.plus | bash` → `vp env setup`) creates. `vp` is a multi-call binary dispatching on `argv[0]` (`vpr` → `vp run`, `vpx` → `vp dlx`).
- Translate all remaining Japanese code comments to English (`flake.nix`, `pkgs/vite-plus.nix`).

## What is deliberately NOT done

- The `node` / `npm` / `npx` / `corepack` shims also created by `vp env setup` are not reproduced: they belong to the opt-out-able Node version manager component and would conflict with Nix-managed Node.
- The Japanese strings in `home/claude.nix` are `spinnerVerbs` data, not comments — intentionally kept.

## Verification

```
$ nix build .#vite-plus --no-link --print-out-paths
$ ls result/bin
vp  vpr  vpx
$ ./result/bin/vpr --help | head -1
Usage: vp run [OPTIONS] [TASK_SPECIFIER] [ADDITIONAL_ARGS]...
$ ./result/bin/vpx --help | head -1
Execute a command from a local or remote npm package
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)