### PR TITLE
chore: bump nvfetcher workflow actions off Node 20 (checkout v7, create-pull-request v8)

### DIFF
--- a/.github/workflows/nvfetcher.yml
+++ b/.github/workflows/nvfetcher.yml
@@ -14,7 +14,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: cachix/install-nix-action@v31
 
@@ -24,7 +24,7 @@ jobs:
           nix run nixpkgs#nvfetcher -- --keyfile "$RUNNER_TEMP/keyfile.toml" -o pkgs/_sources
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: nvfetcher-update
           commit-message: "chore: update nvfetcher sources"


### PR DESCRIPTION
Closes #354

## Context

The scheduled nvfetcher run [30133492301](https://github.com/naitokosuke/dotfiles/actions/runs/30133492301) failed at the **Create pull request** step because the repository setting "Allow GitHub Actions to create and approve pull requests" was disabled. That root cause has already been fixed manually in the repo settings (`can_approve_pull_request_reviews` is now `true`).

This PR handles the remaining code-side cleanup: the same run annotated Node.js 20 deprecation warnings for `actions/checkout@v4` and `peter-evans/create-pull-request@v7`.

## Changes

- `actions/checkout` v4 → v7 — v5–v7 breaking changes (Node 24 requirement, creds file split, fork-PR checkout block for `pull_request_target`/`workflow_run`) don't affect this schedule/workflow_dispatch workflow
- `peter-evans/create-pull-request` v7 → v8 — only requires a Node 24-capable runner; all inputs used here are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)