### PR TITLE
feat: manage ssh, gh-dash and gomi configs via home-manager

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -9,14 +9,17 @@
     ./atuin.nix
     ./claude.nix
     ./direnv.nix
+    ./gh-dash.nix
     ./gh.nix
     ./ghostty.nix
     ./git.nix
+    ./gomi.nix
     ./gwq.nix
     ./mcp.nix
     ./octorus.nix
     ./playwright.nix
     ./shell
+    ./ssh.nix
     ./starship.nix
     ./vscode.nix
     ./zoxide.nix

--- a/home/gh-dash.nix
+++ b/home/gh-dash.nix
@@ -1,0 +1,133 @@
+# gh-dash configuration
+#
+# gh-dash is a TUI dashboard for GitHub PRs, issues and notifications.
+# The module installs the package and registers it as a gh extension,
+# so it is available both as `gh-dash` and `gh dash`.
+# https://github.com/dlvhdr/gh-dash
+{
+  programs.gh-dash = {
+    enable = true;
+    settings = {
+      prSections = [
+        {
+          title = "My Pull Requests";
+          filters = "is:open author:@me";
+        }
+        {
+          title = "Needs My Review";
+          filters = "is:open review-requested:@me";
+        }
+        {
+          title = "Involved";
+          filters = "is:open involves:@me -author:@me";
+        }
+      ];
+      issuesSections = [
+        {
+          title = "My Issues";
+          filters = "is:open author:@me";
+        }
+        {
+          title = "Assigned";
+          filters = "is:open assignee:@me";
+        }
+        {
+          title = "Involved";
+          filters = "is:open involves:@me -author:@me";
+        }
+      ];
+      notificationsSections = [
+        {
+          title = "All";
+          filters = "";
+        }
+        {
+          title = "Created";
+          filters = "reason:author";
+        }
+        {
+          title = "Participating";
+          filters = "reason:participating";
+        }
+        {
+          title = "Mentioned";
+          filters = "reason:mention";
+        }
+        {
+          title = "Review Requested";
+          filters = "reason:review-requested";
+        }
+        {
+          title = "Assigned";
+          filters = "reason:assign";
+        }
+        {
+          title = "Subscribed";
+          filters = "reason:subscribed";
+        }
+        {
+          title = "Team Mentioned";
+          filters = "reason:team-mention";
+        }
+      ];
+      repo = {
+        branchesRefetchIntervalSeconds = 30;
+        prsRefetchIntervalSeconds = 60;
+      };
+      defaults = {
+        preview = {
+          open = true;
+          width = 50;
+        };
+        prsLimit = 20;
+        prApproveComment = "LGTM";
+        issuesLimit = 20;
+        notificationsLimit = 20;
+        view = "prs";
+        layout = {
+          prs = {
+            updatedAt.width = 5;
+            createdAt.width = 5;
+            repo.width = 20;
+            author.width = 15;
+            authorIcon.hidden = false;
+            assignees = {
+              width = 20;
+              hidden = true;
+            };
+            base = {
+              width = 15;
+              hidden = true;
+            };
+            lines.width = 15;
+          };
+          issues = {
+            updatedAt.width = 5;
+            createdAt.width = 5;
+            repo.width = 15;
+            creator.width = 10;
+            creatorIcon.hidden = false;
+            assignees = {
+              width = 20;
+              hidden = true;
+            };
+          };
+        };
+        refetchIntervalMinutes = 30;
+      };
+      keybindings = { };
+      repoPaths = { };
+      theme.ui = {
+        sectionsShowCount = true;
+        table = {
+          showSeparator = true;
+          compact = false;
+        };
+      };
+      pager.diff = "";
+      confirmQuit = false;
+      showAuthorIcons = true;
+      smartFilteringAtLaunch = true;
+    };
+  };
+}

--- a/home/gomi.nix
+++ b/home/gomi.nix
@@ -1,0 +1,112 @@
+# gomi configuration
+#
+# gomi is a trash-can alternative to rm.
+# The package and the daily prune launchd agent are managed in
+# hosts/common/gomi.nix; this module manages the user configuration.
+# https://github.com/babarot/gomi
+{
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  xdg.configFile."gomi/config.yaml".source = yamlFormat.generate "gomi-config.yaml" {
+    core = {
+      trash = {
+        strategy = "auto";
+        home_fallback = true;
+        gomi_dir = "${config.home.homeDirectory}/.gomi";
+        forbidden_paths = [
+          "$HOME/.local/share/Trash"
+          "$HOME/.trash"
+          "$XDG_DATA_HOME/Trash"
+          "/tmp/Trash"
+          "/var/tmp/Trash"
+          "$HOME/.gomi"
+          "/"
+          "/etc"
+          "/usr"
+          "/var"
+          "/bin"
+          "/sbin"
+          "/lib"
+          "/lib64"
+        ];
+      };
+      restore = {
+        confirm = true;
+        verbose = true;
+      };
+      permanent_delete.enable = false;
+      trash_dir = "";
+    };
+    ui = {
+      density = "spacious";
+      style = {
+        list_view = {
+          indent_on_select = true;
+          cursor = "#AD58B4";
+          selected = "#5FB458";
+          filter_match = "#F39C12";
+          filter_prompt = "#7AA2F7";
+        };
+        detail_view = {
+          border = "#EEEEDD";
+          info_pane = {
+            deleted_from = {
+              fg = "#EEEEEE";
+              bg = "#1C1C1C";
+            };
+            deleted_at = {
+              fg = "#EEEEEE";
+              bg = "#1C1C1C";
+            };
+          };
+          preview_pane = {
+            border = "#3C3C3C";
+            size = {
+              fg = "#EEEEDD";
+              bg = "#3C3C3C";
+            };
+            scroll = {
+              fg = "#EEEEDD";
+              bg = "#3C3C3C";
+            };
+          };
+        };
+        deletion_dialog = "#FF007F";
+      };
+      exit_message = "";
+      preview = {
+        syntax_highlight = true;
+        colorscheme = "nord";
+        directory_command = "ls -GF -1 -A --color=always";
+      };
+      paginator_type = "dots";
+    };
+    history = {
+      include.within_days = 365;
+      exclude = {
+        files = [ ".DS_Store" ];
+        patterns = [ ];
+        globs = [ ];
+        size = {
+          min = "0KB";
+          max = "10GB";
+        };
+      };
+    };
+    logging = {
+      enabled = true;
+      level = "debug";
+      rotation = {
+        max_size = "10MB";
+        max_files = 3;
+      };
+    };
+  };
+}

--- a/home/ssh.nix
+++ b/home/ssh.nix
@@ -1,0 +1,25 @@
+# SSH client configuration
+#
+# Private or machine-local host definitions (e.g. work servers) should not
+# live in this repository; put them in ~/.ssh/config.d/ instead, which is
+# pulled in via the Include directive below.
+{
+  programs.ssh = {
+    enable = true;
+
+    # Don't emit home-manager's implicit "*" defaults; write only the
+    # settings declared below
+    enableDefaultConfig = false;
+
+    # Untracked host definitions (work servers etc.)
+    includes = [ "config.d/*" ];
+
+    settings."github.com" = {
+      AddKeysToAgent = true;
+      # macOS: remember the key passphrase in Keychain
+      UseKeychain = true;
+      IdentityFile = "~/.ssh/id_ed25519";
+      IdentitiesOnly = true;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Migrate three previously hand-maintained config files to declarative home-manager modules, following the fully-declarative style of takeokunn/nixos-configuration:

- **`home/ssh.nix`** — `programs.ssh` replaces the hand-written `~/.ssh/config`. Sets `enableDefaultConfig = false` so only declared settings are emitted, and adds `Include config.d/*` so private/work host definitions can stay out of the repo.
- **`home/gh-dash.nix`** — `programs.gh-dash` with the full settings from the existing `config.yml`. This also installs gh-dash itself and registers it as a gh extension (previously only a stale config existed with no binary installed).
- **`home/gomi.nix`** — generates `config.yaml` with `pkgs.formats.yaml` (same pattern as `gwq.nix`), with `gomi_dir` derived from `home.homeDirectory` instead of a hard-coded absolute path.

## Verification

- `darwin-rebuild switch --flake .#Macbook-heavy` applied cleanly; all three files are now home-manager symlinks
- Generated gh-dash/gomi YAML verified semantically identical to the previous hand-maintained files (yq sort_keys + diff)
- `ssh -T git@github.com` authenticates successfully with the generated config
- `gomi` deletes/trashes normally with the generated config; `gh-dash` and `gh dash` both launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)