### PR TITLE
feat: disable the Nushell welcome banner on shell launch

### DIFF
--- a/home/shell/nushell.nix
+++ b/home/shell/nushell.nix
@@ -19,6 +19,9 @@ in
   programs.nushell = {
     enable = true;
 
+    # Nushell settings (assigned to $env.config)
+    settings.show_banner = false;
+
     # Shell aliases (inherit common + nushell-specific)
     shellAliases = common.aliases // {
       cl = "^clear"; # External command (nushell syntax)


### PR DESCRIPTION
## Summary

Disable the multi-line welcome banner Nushell prints on every interactive session start, using Home Manager's declarative `programs.nushell.settings` option (emitted into config.nu as `$env.config.show_banner = false`).

## Changes

- `home/shell/nushell.nix`: add `settings.show_banner = false`

## Verification

- `nix build .#darwinConfigurations.Macbook-heavy.system` succeeds
- Generated `config.nu` contains `$env.config.show_banner = false`

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)