### PR TITLE
fix: fetch skill-skill-skill from GitHub instead of a local path

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,15 +284,15 @@
       "locked": {
         "lastModified": 1782006020,
         "narHash": "sha256-byG6iYnmAR0BXx+7zOvcUoCf1cIHNR/MR+xsW5J5lms=",
-        "ref": "refs/heads/main",
+        "owner": "naitokosuke",
+        "repo": "skill-skill-skill",
         "rev": "eadadf3504607e1ba079167df77e24647fc31b25",
-        "revCount": 16,
-        "type": "git",
-        "url": "file:///Users/naitokosuke/src/github.com/naitokosuke/skill-skill-skill"
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "file:///Users/naitokosuke/src/github.com/naitokosuke/skill-skill-skill"
+        "owner": "naitokosuke",
+        "repo": "skill-skill-skill",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,11 +23,12 @@
     vscode-settings.url = "github:naitokosuke/vscode-settings";
     vscode-settings.flake = false;
 
-    # Claude Code skills - non-flake local input; home/claude.nix readDirs the
+    # Claude Code skills - non-flake input; home/claude.nix readDirs the
     # locked snapshot to discover skill names in pure eval.
-    # Resync after adding/removing a skill: nix flake update skill-skill-skill
+    # Resync after adding/removing a skill: push it, then
+    #   nix flake update skill-skill-skill
     skill-skill-skill = {
-      url = "git+file:///Users/naitokosuke/src/github.com/naitokosuke/skill-skill-skill";
+      url = "github:naitokosuke/skill-skill-skill";
       flake = false;
     };
 

--- a/home/claude.nix
+++ b/home/claude.nix
@@ -145,7 +145,7 @@ in
       # Skill names are discovered from the locked skill-skill-skill input
       # (pure eval cannot readDir the live working tree). The links themselves
       # still point at the working tree, so skill *content* stays live.
-      # After adding/removing a skill: commit it, then
+      # After adding/removing a skill: push it, then
       #   nix flake update skill-skill-skill
       skillNames = builtins.attrNames (
         lib.filterAttrs (_: type: type == "directory") (


### PR DESCRIPTION
Closes #359

## Problem

The `skill-skill-skill` flake input was declared as `git+file:///Users/naitokosuke/src/github.com/naitokosuke/skill-skill-skill`.
Evaluation failed on any machine where that path does not exist, so a fresh checkout could not build or run `nix flake update` until that repository was cloned to the exact same path.
This was the only input breaking the guarantee that `flake.lock` alone reproduces the system.

## Change

- Declare the input as `github:naitokosuke/skill-skill-skill`
- Re-lock the input: same revision (`eadadf3`), now fetched from GitHub
- Update the resync comments in `flake.nix` and `home/claude.nix` (push instead of commit)

Skill content stays live: the input is only used to discover skill names in pure eval, while the symlinks keep pointing at the ghq working tree.
The local repository is in sync with `origin/main` at the locked revision, so the discovered skill set is unchanged.

## Verification

`nix eval` of the home-manager `home.file` attribute names resolves all 15 `.claude/skills/*` links from the GitHub-fetched snapshot.
`nix fmt` reports no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)