### PR TITLE
fix: reconcile declared Claude Code settings into the live settings.json

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -132,7 +132,6 @@ in
     let
       ghqRoot = "${config.home.homeDirectory}/src/github.com/${config.home.username}";
       link = path: { source = config.lib.file.mkOutOfStoreSymlink "${ghqRoot}/${path}"; };
-      yamlFormat = pkgs.formats.yaml { };
       # Skill names are discovered from the locked skill-skill-skill input
       # (pure eval cannot readDir the live working tree). The links themselves
       # still point at the working tree, so skill *content* stays live.
@@ -152,16 +151,6 @@ in
     {
       ".claude/rules" = link "rule-rule-rule/rules";
       ".claude/CLAUDE.md" = link "rule-rule-rule/CLAUDE.md";
-
-      # Serena config. A store symlink on purpose: the previous "writable copy"
-      # activation had left this file read-only and byte-identical to the
-      # declared content ever since it was first created, i.e. Serena never
-      # writes to it, so it does not need the settings.json merge treatment.
-      ".serena/serena_config.yml".source = yamlFormat.generate "serena_config.yml" {
-        gui_log_window = false;
-        web_dashboard = false;
-        projects = { };
-      };
     }
     // skillLinks;
 }

--- a/home/claude.nix
+++ b/home/claude.nix
@@ -7,129 +7,119 @@
 }:
 
 let
-  # Helper: create a writable config file (not a Nix store symlink)
-  # Removes leftover symlinks, copies only if file doesn't exist (preserving runtime changes)
-  mkWritableConfig =
-    {
-      dir,
-      filename,
-      content,
-    }:
-    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      target="${dir}/${filename}"
-      run mkdir -p "${dir}"
-      [ -L "$target" ] && run rm "$target"
-      [ ! -f "$target" ] && run cp ${content} "$target"
-    '';
+  # ~/.claude/settings.json must stay a writable real file, not a store
+  # symlink: Claude Code writes runtime state into it (model, language,
+  # enabledPlugins, plugin hooks, ...). Copying it only when missing kept
+  # those runtime edits but silently dropped every later change to the
+  # declared settings (issue #361), so the activation instead deep-merges
+  # the declared settings into the live file on every rebuild:
+  #   - declared keys are authoritative (arrays are replaced wholesale)
+  #   - keys that exist only in the live file survive
+  claudeSettings = pkgs.writeText "claude-settings.json" (
+    builtins.toJSON {
+      installMethod = "unknown";
+      autoUpdates = true;
+      theme = "dark-daltonized";
+      verbose = false;
+      preferredNotifChannel = "auto";
+      shiftEnterKeyBindingInstalled = true;
+      editorMode = "normal";
+      spinnerVerbs = {
+        mode = "replace";
+        verbs = [
+          "考え中"
+          "深く考え中"
+          "実装中"
+          "リファクタリング中"
+          "調査中"
+        ];
+      };
+      hasUsedBackslashReturn = true;
+      autoCompactEnabled = true;
+      diffTool = "auto";
+      env = {
+        DISABLE_AUTOUPDATER = "1";
+        DISABLE_INSTALLATION_CHECKS = "1";
+      };
+      todoFeatureEnabled = true;
+      messageIdleNotifThresholdMs = 60000;
+      autoConnectIde = false;
+      autoInstallIdeExtension = true;
+      checkpointingEnabled = true;
+      # Permissions reference:
+      #   https://code.claude.com/docs/en/permissions
+      #   https://www.claudedirectory.org/blog/claude-code-permissions-guide
+      #   https://www.backslash.security/blog/claude-code-security-best-practices
+      # Known issue (deny may be ignored on older versions): https://github.com/anthropics/claude-code/issues/6699
+      permissions = {
+        deny = [
+          # Joke: discourage legacy / non-preferred runtimes
+          "Bash(perl:*)"
+          "Bash(python:*)"
+          "Bash(python3:*)"
+
+          # Credentials and secrets (gitignore semantics, recursive)
+          "Read(.env)"
+          "Read(.env.*)"
+          "Read(./secrets/**)"
+          "Read(**/credentials.json)"
+          "Read(~/.ssh/**)"
+          "Read(~/.aws/**)"
+          "Read(~/.gnupg/**)"
+
+          # Destructive shell — root / home wipes still trip the circuit breaker,
+          # but make it explicit
+          "Bash(rm -rf /:*)"
+          "Bash(rm -rf ~:*)"
+          "Bash(rm -rf ~/:*)"
+
+          # Force-push protection (regular push stays in `ask`/allow)
+          "Bash(git push --force:*)"
+          "Bash(git push -f:*)"
+          "Bash(git push * --force:*)"
+          "Bash(git push * -f:*)"
+
+          # Prefer WebFetch with explicit domain over raw curl/wget
+          "Bash(curl:*)"
+          "Bash(wget:*)"
+        ];
+      };
+      hooks = {
+        PreToolUse = [
+          {
+            matcher = "ExitPlanMode";
+            hooks = [
+              {
+                type = "command";
+                command = ''code "$(ls -t ~/.claude/plans/*.md | head -1)"'';
+                timeout = 5;
+              }
+            ];
+          }
+        ];
+      };
+    }
+  );
 in
 {
-  # Claude Code settings - writable file, not symlink
-  # Claude Code needs write access for resume functionality and session management
-  home.activation.claudeSettings = mkWritableConfig {
-    dir = "$HOME/.claude";
-    filename = "settings.json";
-    content = pkgs.writeText "claude-settings.json" (
-      builtins.toJSON {
-        installMethod = "unknown";
-        autoUpdates = true;
-        theme = "dark-daltonized";
-        verbose = false;
-        preferredNotifChannel = "auto";
-        shiftEnterKeyBindingInstalled = true;
-        editorMode = "normal";
-        spinnerVerbs = {
-          mode = "replace";
-          verbs = [
-            "考え中"
-            "深く考え中"
-            "実装中"
-            "リファクタリング中"
-            "調査中"
-          ];
-        };
-        hasUsedBackslashReturn = true;
-        autoCompactEnabled = true;
-        diffTool = "auto";
-        env = {
-          DISABLE_AUTOUPDATER = "1";
-          DISABLE_INSTALLATION_CHECKS = "1";
-        };
-        todoFeatureEnabled = true;
-        messageIdleNotifThresholdMs = 60000;
-        autoConnectIde = false;
-        autoInstallIdeExtension = true;
-        checkpointingEnabled = true;
-        # Permissions reference:
-        #   https://code.claude.com/docs/en/permissions
-        #   https://www.claudedirectory.org/blog/claude-code-permissions-guide
-        #   https://www.backslash.security/blog/claude-code-security-best-practices
-        # Known issue (deny may be ignored on older versions): https://github.com/anthropics/claude-code/issues/6699
-        permissions = {
-          deny = [
-            # Joke: discourage legacy / non-preferred runtimes
-            "Bash(perl:*)"
-            "Bash(python:*)"
-            "Bash(python3:*)"
-
-            # Credentials and secrets (gitignore semantics, recursive)
-            "Read(.env)"
-            "Read(.env.*)"
-            "Read(./secrets/**)"
-            "Read(**/credentials.json)"
-            "Read(~/.ssh/**)"
-            "Read(~/.aws/**)"
-            "Read(~/.gnupg/**)"
-
-            # Destructive shell — root / home wipes still trip the circuit breaker,
-            # but make it explicit
-            "Bash(rm -rf /:*)"
-            "Bash(rm -rf ~:*)"
-            "Bash(rm -rf ~/:*)"
-
-            # Force-push protection (regular push stays in `ask`/allow)
-            "Bash(git push --force:*)"
-            "Bash(git push -f:*)"
-            "Bash(git push * --force:*)"
-            "Bash(git push * -f:*)"
-
-            # Prefer WebFetch with explicit domain over raw curl/wget
-            "Bash(curl:*)"
-            "Bash(wget:*)"
-          ];
-        };
-        hooks = {
-          PreToolUse = [
-            {
-              matcher = "ExitPlanMode";
-              hooks = [
-                {
-                  type = "command";
-                  command = ''code "$(ls -t ~/.claude/plans/*.md | head -1)"'';
-                  timeout = 5;
-                }
-              ];
-            }
-          ];
-        };
-      }
-    );
-  };
-
-  # Serena config - writable file, not symlink
-  # Serena needs write access for runtime configuration
-  home.activation.serenaConfig = mkWritableConfig {
-    dir = "$HOME/.serena";
-    filename = "serena_config.yml";
-    content =
-      let
-        yamlFormat = pkgs.formats.yaml { };
-      in
-      yamlFormat.generate "serena_config.yml" {
-        gui_log_window = false;
-        web_dashboard = false;
-        projects = { };
-      };
-  };
+  home.activation.claudeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    target="$HOME/.claude/settings.json"
+    run mkdir -p "$HOME/.claude"
+    # Drop the store symlink left behind by the pre-2026 home.file approach
+    [ -L "$target" ] && run rm "$target"
+    if [ ! -f "$target" ]; then
+      run install -m 644 ${claudeSettings} "$target"
+    else
+      merged="$HOME/.claude/.settings.json.merged"
+      ${lib.getExe pkgs.jq} -s '.[0] * .[1]' "$target" ${claudeSettings} > "$merged"
+      if ${pkgs.diffutils}/bin/cmp -s "$merged" "$target"; then
+        rm -f "$merged"
+      else
+        run mv "$merged" "$target"
+        rm -f "$merged"
+      fi
+    fi
+  '';
 
   # Claude Code rules, CLAUDE.md and skills - out-of-store symlinks into the
   # rule-rule-rule / skill-skill-skill repositories.
@@ -142,6 +132,7 @@ in
     let
       ghqRoot = "${config.home.homeDirectory}/src/github.com/${config.home.username}";
       link = path: { source = config.lib.file.mkOutOfStoreSymlink "${ghqRoot}/${path}"; };
+      yamlFormat = pkgs.formats.yaml { };
       # Skill names are discovered from the locked skill-skill-skill input
       # (pure eval cannot readDir the live working tree). The links themselves
       # still point at the working tree, so skill *content* stays live.
@@ -161,6 +152,16 @@ in
     {
       ".claude/rules" = link "rule-rule-rule/rules";
       ".claude/CLAUDE.md" = link "rule-rule-rule/CLAUDE.md";
+
+      # Serena config. A store symlink on purpose: the previous "writable copy"
+      # activation had left this file read-only and byte-identical to the
+      # declared content ever since it was first created, i.e. Serena never
+      # writes to it, so it does not need the settings.json merge treatment.
+      ".serena/serena_config.yml".source = yamlFormat.generate "serena_config.yml" {
+        gui_log_window = false;
+        web_dashboard = false;
+        projects = { };
+      };
     }
     // skillLinks;
 }


### PR DESCRIPTION
Closes #361
Closes #372

## Problem

The copy-once activation (#232 / #239) preserved runtime edits but silently dropped every later change to the declared settings.
On the live machine this was real drift: `spinnerVerbs` (#309) and the entire `permissions.deny` list (19 rules, including secrets-read and force-push protection) never reached `~/.claude/settings.json`, while the file accumulated runtime-only keys (`model`, `language`, `enabledPlugins`, a SessionStart hook) unknown to the repository.

## Change

`~/.claude/settings.json` stays a writable real file, but the activation now runs `jq -s '.[0] * .[1]' live declared` on every rebuild.

- Declared keys are authoritative; arrays are replaced wholesale
- Keys that exist only in the live file survive (what #232 wanted to protect)
- The file is rewritten only when the merge actually changes it, atomically via `mv`
- Fresh installs get the declared content as a writable 644 file (the old `cp` from the store produced a read-only copy)

Serena configuration is removed entirely (#372).
Serena is not installed by any module, not registered as an MCP server, and its config file had been read-only and byte-identical to the declared content since 2025-12-30 — it never ran against it.
The stale `~/.serena/` directory on the live machine has been deleted manually.

## Verification

Ran the built activation script (real store paths) against sandbox homes:

- Fresh home: file created, mode 644, content equals declared
- Copy of the real live file: `spinnerVerbs` and 19 deny rules propagated; `model`, `language`, `enabledPlugins`, SessionStart hook, ExitPlanMode hook, and `env` all preserved; no temp file left behind
- Second run: byte-identical, no rewrite
- Leftover store symlink: replaced with a real file

After the Serena removal, `grep -i serena` over the repository returns nothing and the module still evaluates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)