### PR TITLE
fix: run chrome-devtools-mcp from a Nix-pinned package instead of npx @latest

### DIFF
--- a/home/mcp.nix
+++ b/home/mcp.nix
@@ -4,19 +4,17 @@
 # central registry, and lets programs.claude-code consume servers declaratively.
 #
 # https://github.com/natsukium/mcp-servers-nix
-{ ... }:
+{ lib, pkgs, ... }:
 
 {
   mcp-servers.settings.servers = {
     # Chrome DevTools MCP — not covered by mcp-servers-nix's built-in modules,
-    # declared via the freeform `settings.servers` escape hatch.
+    # declared via the freeform `settings.servers` escape hatch. The server
+    # itself is the Nix-packaged pkgs.chrome-devtools-mcp (./pkgs), not an
+    # `npx -y ...@latest` fetched from the registry at launch time.
     # https://github.com/ChromeDevTools/chrome-devtools-mcp
     chrome-devtools = {
-      command = "npx";
-      args = [
-        "-y"
-        "chrome-devtools-mcp@latest"
-      ];
+      command = lib.getExe pkgs.chrome-devtools-mcp;
     };
   };
 

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -26,3 +26,12 @@ fetch.url = "https://github.com/voidzero-dev/vite-plus/releases/download/$ver/vp
 [playwright-cli]
 src.github = "microsoft/playwright-cli"
 fetch.github = "microsoft/playwright-cli"
+
+# The published npm tarball bundles all dependencies (rollup) and ships the
+# built JS, so it is consumed directly — no npm install, no TypeScript build.
+# Release tags carry a "chrome-devtools-mcp-v" prefix, stripped here so $ver
+# matches the npm version.
+[chrome-devtools-mcp]
+src.github = "ChromeDevTools/chrome-devtools-mcp"
+src.prefix = "chrome-devtools-mcp-v"
+fetch.url = "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-$ver.tgz"

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -14,6 +14,21 @@
         },
         "version": "v0.1.22"
     },
+    "chrome-devtools-mcp": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "chrome-devtools-mcp",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-HmMsLZcUtPgrTPq077nOV1CFx1/+XpdyODEprwEsnIQ=",
+            "type": "url",
+            "url": "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-1.6.0.tgz"
+        },
+        "version": "1.6.0"
+    },
     "octorus-darwin-arm64": {
         "cargoLock": null,
         "date": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -14,6 +14,14 @@
       sha256 = "sha256-gZXl4wd6/UzlqwWap+WmjhPeuc1g/7Iwq6Z1HDOeIjQ=";
     };
   };
+  chrome-devtools-mcp = {
+    pname = "chrome-devtools-mcp";
+    version = "1.6.0";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-1.6.0.tgz";
+      sha256 = "sha256-HmMsLZcUtPgrTPq077nOV1CFx1/+XpdyODEprwEsnIQ=";
+    };
+  };
   octorus-darwin-arm64 = {
     pname = "octorus-darwin-arm64";
     version = "0.6.7";

--- a/pkgs/chrome-devtools-mcp.nix
+++ b/pkgs/chrome-devtools-mcp.nix
@@ -1,0 +1,49 @@
+# MCP server exposing Chrome DevTools to coding agents.
+# The published npm tarball bundles all dependencies and ships prebuilt JS
+# (dependencies = {}), so it is unpacked as-is and wrapped with node — the
+# same "official artifact" approach as the binary packages here.
+# Consumed by home/mcp.nix via its store path.
+{
+  lib,
+  stdenvNoCC,
+  makeBinaryWrapper,
+  nodejs,
+  sources,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "chrome-devtools-mcp";
+  inherit (sources.chrome-devtools-mcp) version;
+  src = sources.chrome-devtools-mcp.src;
+
+  # npm tarballs unpack to a top-level "package" directory
+  sourceRoot = "package";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/chrome-devtools-mcp
+    cp -r . $out/lib/chrome-devtools-mcp/
+    makeWrapper ${lib.getExe nodejs} $out/bin/chrome-devtools-mcp \
+      --add-flags $out/lib/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    version_output=$($out/bin/chrome-devtools-mcp --version)
+    [ "$version_output" = "${sources.chrome-devtools-mcp.version}" ]
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Chrome DevTools MCP server for browser automation and debugging";
+    homepage = "https://github.com/ChromeDevTools/chrome-devtools-mcp";
+    changelog = "https://github.com/ChromeDevTools/chrome-devtools-mcp/releases/tag/chrome-devtools-mcp-v${sources.chrome-devtools-mcp.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "chrome-devtools-mcp";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6,6 +6,7 @@ let
 in
 {
   ax = pkgs.callPackage ./ax.nix { inherit sources; };
+  chrome-devtools-mcp = pkgs.callPackage ./chrome-devtools-mcp.nix { inherit sources; };
   octorus = pkgs.callPackage ./octorus.nix { inherit sources; };
   playwright-cli = pkgs.callPackage ./playwright-cli.nix { inherit sources; };
   vite-plus = pkgs.callPackage ./vite-plus.nix { inherit sources; };


### PR DESCRIPTION
Closes #365

## Problem

`home/mcp.nix` declared the server as `npx -y chrome-devtools-mcp@latest`.
The package was resolved from the npm registry at launch time, so the code that actually ran depended on the moment of execution and network availability — unpinned code execution on every MCP client start.

## Change

`pkgs/chrome-devtools-mcp.nix` packages the official published npm tarball, tracked by nvfetcher (`1.6.0` locked, registry URL + hash pinned).
The tarball bundles all dependencies via rollup and ships prebuilt JS (`dependencies = {}`), so the derivation just unpacks it and wraps the entry point with `node` — the same "official artifact" approach as the binary packages, with no `npmDepsHash` to maintain.
`home/mcp.nix` now points the server command at the package via `lib.getExe`.

A `buildNpmPackage` source build was tried first and rejected: the repo does not commit its `build/` output and its tsc build fails against the vendored `chrome-devtools-frontend` types (TS2717).

## Verification

- `nix build .#chrome-devtools-mcp` succeeds; `installCheckPhase` asserts `--version` prints exactly `1.6.0`
- The generated MCP config now reads `"command": "/nix/store/…-chrome-devtools-mcp-1.6.0/bin/chrome-devtools-mcp"`
- Standalone run of the tarball's entry point with bare `node` confirmed the zero-dependency claim before packaging
- `nix fmt` reports no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)