### PR TITLE
fix: make Homebrew fully declarative

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -128,6 +128,38 @@
         "type": "github"
       }
     },
+    "homebrew-core": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785223996,
+        "narHash": "sha256-biRfPDf0qHz8ht9/wGxhYeVm31oUcJ3KLQ3IG9Yyp7g=",
+        "owner": "homebrew",
+        "repo": "homebrew-core",
+        "rev": "4160c6d98b94f03a9eebd05d90aebe9c035c37c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "homebrew",
+        "repo": "homebrew-core",
+        "type": "github"
+      }
+    },
+    "homebrew-productdevbook": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783067114,
+        "narHash": "sha256-QxmXaW2VSlk+Bea8AHCu6oErgPY9jLPPkiCt3NKfpcA=",
+        "owner": "productdevbook",
+        "repo": "homebrew-tap",
+        "rev": "01184d042ecbe1a22a9373070b6e6280ecd77b5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "productdevbook",
+        "repo": "homebrew-tap",
+        "type": "github"
+      }
+    },
     "llm-agents": {
       "inputs": {
         "bun2nix": "bun2nix",
@@ -247,6 +279,8 @@
         "herdr": "herdr",
         "home-manager": "home-manager",
         "homebrew-cask": "homebrew-cask",
+        "homebrew-core": "homebrew-core",
+        "homebrew-productdevbook": "homebrew-productdevbook",
         "llm-agents": "llm-agents",
         "mcp-servers-nix": "mcp-servers-nix",
         "nix-darwin": "nix-darwin",

--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,21 @@
 
     nix-homebrew.url = "github:zhaofengli/nix-homebrew";
 
+    # brew bundle unconditionally loads the core tap when
+    # HOMEBREW_NO_INSTALL_FROM_API is set, so it must be pinned even though
+    # no formulae are installed via Homebrew.
+    homebrew-core = {
+      url = "github:homebrew/homebrew-core";
+      flake = false;
+    };
+
     homebrew-cask = {
       url = "github:homebrew/homebrew-cask";
+      flake = false;
+    };
+
+    homebrew-productdevbook = {
+      url = "github:productdevbook/homebrew-tap";
       flake = false;
     };
 

--- a/hosts/common/homebrew.nix
+++ b/hosts/common/homebrew.nix
@@ -11,25 +11,33 @@
     user = config.naitokosuke.username;
     autoMigrate = true;
     taps = {
+      "homebrew/homebrew-core" = inputs.homebrew-core;
       "homebrew/homebrew-cask" = inputs.homebrew-cask;
+      "productdevbook/homebrew-tap" = inputs.homebrew-productdevbook;
     };
-    mutableTaps = true;
+    # Taps are read-only and pinned by flake.lock; `brew tap` is disabled.
+    mutableTaps = false;
   };
 
   homebrew = {
     enable = true;
 
-    taps = [
-      {
-        name = "productdevbook/tap";
-        trusted = true;
-      }
-    ];
+    # Mirror the nix-homebrew-pinned taps into the Brewfile so
+    # `brew bundle` cleanup does not try to untap them.
+    taps = builtins.attrNames config.nix-homebrew.taps;
 
+    # Fully declarative (issue #363): cask definitions come from the
+    # flake-pinned taps (HOMEBREW_NO_INSTALL_FROM_API), so activation
+    # converges installed apps to what flake.lock pins — new versions arrive
+    # via `nix flake update` + rebuild, and casks removed from the list below
+    # are uninstalled. Most of these apps still self-update independently.
     onActivation = {
-      autoUpdate = true;
+      autoUpdate = false;
       upgrade = true;
-      cleanup = "none";
+      cleanup = "uninstall";
+      extraEnv = {
+        HOMEBREW_NO_INSTALL_FROM_API = "1";
+      };
     };
 
     casks = [

--- a/hosts/common/packages.nix
+++ b/hosts/common/packages.nix
@@ -38,6 +38,9 @@ in
   environment.systemPackages = with pkgs; [
     ax
     bun
+    # Moved from an undeclared brew formula when homebrew went fully
+    # declarative (issue #363)
+    cargo-deny
     llm-agents.claude-code
     darwin-rebuild-nom
     devenv


### PR DESCRIPTION
Closes #363

## Problem

Every `darwin-rebuild switch` could change installed software in ways not described by the repository at that commit: `autoUpdate`/`upgrade` pulled whatever was latest, `cleanup = "none"` made the cask list a lower bound instead of a description, `mutableTaps = true` allowed imperative taps, and casks resolved through the Homebrew API — silently bypassing the flake-pinned `homebrew-cask` tap (the rebuild log even said "Installing from the API is now the default behaviour!").

## Change

- `HOMEBREW_NO_INSTALL_FROM_API=1` via `onActivation.extraEnv`: cask definitions now come from the flake-locked taps, so `flake.lock` pins what gets installed; updates arrive via `nix flake update` + rebuild
- `homebrew-core` joins the pinned taps: `brew bundle` loads the core tap unconditionally when the API is disabled (verified — it starts cloning the full core repo otherwise), even with zero formulae installed
- `productdevbook/homebrew-tap` becomes a flake input; `mutableTaps = false` makes all taps read-only
- `autoUpdate = false`, `upgrade = true`: activation converges installed casks to the pinned definitions
- `cleanup = "uninstall"`: removing a cask from the list now uninstalls it
- `cargo-deny`, the single undeclared brew formula, moves to `environment.systemPackages`; it was uninstalled from brew on the live machine ahead of time so the first immutable-tap activation cannot trigger a core clone
- Most of these casks (Chrome, Arc, Discord, Raycast, VSCode, …) self-update independently, so real-world freshness loss is limited

## Verification

Dry-ran the exact generated activation state: built the system closure, took its Brewfile, symlinked the flake-pinned `homebrew-core` into the tap location, and ran `brew bundle cleanup` / `check` with the same env as activation.

- `check`: "The Brewfile's dependencies are satisfied"
- `cleanup`: would only remove stale download caches — no apps, no taps
- Installed casks (13) exactly match the declared list; both host configs build

## Trade-off note

`homebrew-core` and `homebrew-cask` are large inputs; `nix flake update` now downloads fresh snapshots of them when they change (daily upstream). Cask updates only land when the lock is updated and a rebuild runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)