### PR TITLE
fix: parse JSONC keybindings with jsonnet instead of regex surgery

### DIFF
--- a/home/vscode.nix
+++ b/home/vscode.nix
@@ -4,22 +4,16 @@
   pkgs,
   ...
 }:
+
 let
-  # Convert JSONC → JSON using Nix builtins (no Python dependency)
-  rawContent = builtins.readFile "${inputs.vscode-settings}/keybinding.jsonc";
-
-  # Strip full-line // comments
-  lines = lib.splitString "\n" rawContent;
-  withoutComments = builtins.filter (line: builtins.match "[[:space:]]*//.*" line == null) lines;
-  joined = lib.concatStringsSep "\n" withoutComments;
-
-  # Remove trailing commas before ] or }
-  parts = builtins.split ",([[:space:]]*[]}])" joined;
-  cleaned = lib.concatStrings (
-    map (part: if builtins.isList part then builtins.head part else part) parts
-  );
-
-  keybindings-json = pkgs.writeText "keybindings.json" (builtins.toJSON (builtins.fromJSON cleaned));
+  # keybinding.jsonc → spec-compliant JSON, converted at build time.
+  # JSONC (// and /* */ comments, trailing commas) is valid Jsonnet input
+  # and jsonnet emits plain JSON, so this is a real parse — invalid input
+  # fails the build instead of silently corrupting the output the way the
+  # previous regex-based conversion could (issue #364).
+  keybindings-json = pkgs.runCommand "keybindings.json" { } ''
+    ${lib.getExe pkgs.jsonnet} ${inputs.vscode-settings}/keybinding.jsonc -o $out
+  '';
 in
 {
   # VSCode settings configuration


### PR DESCRIPTION
Closes #364

## Problem

The regex-based conversion in `home/vscode.nix` stripped trailing commas with a pattern that also matches inside JSON string values — a keybinding argument containing `,]` or `,}` would be silently rewritten, with no error at evaluation time.
It also only handled full-line `//` comments; inline and `/* */` comments would slip through into `builtins.fromJSON` and fail evaluation.

## Change

JSONC (comments + trailing commas) is valid Jsonnet input, and `jsonnet` emits spec-compliant JSON.
The conversion is now a single `runCommand` derivation running a real parser at build time: invalid input fails the build loudly instead of corrupting the output.
The eval-time `builtins.match` / `builtins.split` / `fromJSON` pipeline is deleted.

## Verification

Built the new derivation and compared it against the regex conversion's output currently deployed on the machine: `jq -S` normalized diff is empty — semantically identical (5 keybindings), so no behavior change today; only the corruption class is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)