### PR TITLE
refactor: move gwq and gh-sub-issue to the pkgs/ + nvfetcher pattern

### DIFF
--- a/home/gh.nix
+++ b/home/gh.nix
@@ -2,27 +2,13 @@
   pkgs,
   ...
 }:
-let
-  # Not available in nixpkgs, so we build from source
-  gh-sub-issue = pkgs.buildGoModule rec {
-    pname = "gh-sub-issue";
-    version = "0.5.1";
 
-    src = pkgs.fetchFromGitHub {
-      owner = "yahsan2";
-      repo = "gh-sub-issue";
-      rev = "v${version}";
-      hash = "sha256-WeQFWa+9dPiyInpDQx52vv9VNOzHrcPJi093WG2nmpA=";
-    };
-
-    vendorHash = "sha256-U4z6S12j9PBAXHNIQT8GgjEELqc6KTeeSVQnoF9Lw2I=";
-  };
-in
 {
   programs.gh = {
     enable = true;
     extensions = [
-      gh-sub-issue
+      # Official prebuilt binary from ./pkgs, tracked by nvfetcher
+      pkgs.gh-sub-issue
     ];
     settings = {
       version = 1;

--- a/hosts/common/packages.nix
+++ b/hosts/common/packages.nix
@@ -5,24 +5,6 @@
 }:
 
 let
-  # Not available in nixpkgs, so we build from source
-  gwq = pkgs.buildGoModule rec {
-    pname = "gwq";
-    version = "0.0.19";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "d-kuro";
-      repo = "gwq";
-      rev = "v${version}";
-      hash = "sha256-2uE04frxfvQBlrOg5d0hPzGE9sbpzxHEiCeJX1ilG2M=";
-    };
-
-    vendorHash = "sha256-4K01Xf1EXl/NVX1loQ76l1bW8QglBAQdvlZSo7J4NPI=";
-
-    # Upstream tests require git in PATH and a writable HOME — skip in the Nix sandbox
-    doCheck = false;
-  };
-
   # darwin-rebuild output piped through nix-output-monitor for richer build progress.
   # darwin-rebuild rejects --log-format and Lix doesn't expose it as a setting,
   # so use nom in its default (non-JSON) mode which parses bare nix output.

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -5,6 +5,17 @@
 src.github = "yusukebe/ax"
 fetch.url = "https://github.com/yusukebe/ax/releases/download/$ver/ax-darwin-arm64"
 
+[gwq-darwin-arm64]
+src.github = "d-kuro/gwq"
+fetch.url = "https://github.com/d-kuro/gwq/releases/download/$ver/gwq_Darwin_arm64.tar.gz"
+
+# The asset name embeds the version without the "v" tag prefix, so strip it
+# here instead of in the derivation.
+[gh-sub-issue-darwin-arm64]
+src.github = "yahsan2/gh-sub-issue"
+src.prefix = "v"
+fetch.url = "https://github.com/yahsan2/gh-sub-issue/releases/download/v$ver/gh-sub-issue_$ver_darwin-arm64"
+
 [vize-darwin-arm64]
 src.github = "ubugeeei-prod/vize"
 fetch.url = "https://github.com/ubugeeei-prod/vize/releases/download/$ver/vize-aarch64-apple-darwin.tar.gz"

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -29,6 +29,36 @@
         },
         "version": "1.6.0"
     },
+    "gh-sub-issue-darwin-arm64": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "gh-sub-issue-darwin-arm64",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-UmVEz2zi7kZF0horOEfP4bZUhA/hwAuE5xrKgZHVSAc=",
+            "type": "url",
+            "url": "https://github.com/yahsan2/gh-sub-issue/releases/download/v0.5.1/gh-sub-issue_0.5.1_darwin-arm64"
+        },
+        "version": "0.5.1"
+    },
+    "gwq-darwin-arm64": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "gwq-darwin-arm64",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-G4tYAEvOL/G4WxJG5rOxTsqJoKlYeWlu5sdc9I571/s=",
+            "type": "url",
+            "url": "https://github.com/d-kuro/gwq/releases/download/v0.1.1/gwq_Darwin_arm64.tar.gz"
+        },
+        "version": "v0.1.1"
+    },
     "octorus-darwin-arm64": {
         "cargoLock": null,
         "date": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -22,6 +22,22 @@
       sha256 = "sha256-HmMsLZcUtPgrTPq077nOV1CFx1/+XpdyODEprwEsnIQ=";
     };
   };
+  gh-sub-issue-darwin-arm64 = {
+    pname = "gh-sub-issue-darwin-arm64";
+    version = "0.5.1";
+    src = fetchurl {
+      url = "https://github.com/yahsan2/gh-sub-issue/releases/download/v0.5.1/gh-sub-issue_0.5.1_darwin-arm64";
+      sha256 = "sha256-UmVEz2zi7kZF0horOEfP4bZUhA/hwAuE5xrKgZHVSAc=";
+    };
+  };
+  gwq-darwin-arm64 = {
+    pname = "gwq-darwin-arm64";
+    version = "v0.1.1";
+    src = fetchurl {
+      url = "https://github.com/d-kuro/gwq/releases/download/v0.1.1/gwq_Darwin_arm64.tar.gz";
+      sha256 = "sha256-G4tYAEvOL/G4WxJG5rOxTsqJoKlYeWlu5sdc9I571/s=";
+    };
+  };
   octorus-darwin-arm64 = {
     pname = "octorus-darwin-arm64";
     version = "0.6.7";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,6 +7,8 @@ in
 {
   ax = pkgs.callPackage ./ax.nix { inherit sources; };
   chrome-devtools-mcp = pkgs.callPackage ./chrome-devtools-mcp.nix { inherit sources; };
+  gh-sub-issue = pkgs.callPackage ./gh-sub-issue.nix { inherit sources; };
+  gwq = pkgs.callPackage ./gwq.nix { inherit sources; };
   octorus = pkgs.callPackage ./octorus.nix { inherit sources; };
   playwright-cli = pkgs.callPackage ./playwright-cli.nix { inherit sources; };
   vite-plus = pkgs.callPackage ./vite-plus.nix { inherit sources; };

--- a/pkgs/gh-sub-issue.nix
+++ b/pkgs/gh-sub-issue.nix
@@ -1,0 +1,32 @@
+# gh extension: programs.gh.extensions links this package's bin/ under
+# ~/.local/share/gh/extensions/<pname>, so pname and the binary name must
+# both be "gh-sub-issue".
+{
+  lib,
+  stdenvNoCC,
+  sources,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "gh-sub-issue";
+  version = sources.gh-sub-issue-darwin-arm64.version;
+  src = sources.gh-sub-issue-darwin-arm64.src;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/gh-sub-issue
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "gh extension for creating and listing GitHub sub-issues";
+    homepage = "https://github.com/yahsan2/gh-sub-issue";
+    changelog = "https://github.com/yahsan2/gh-sub-issue/releases/tag/v${sources.gh-sub-issue-darwin-arm64.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "gh-sub-issue";
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/pkgs/gwq.nix
+++ b/pkgs/gwq.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenvNoCC,
+  versionCheckHook,
+  sources,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "gwq";
+  version = lib.removePrefix "v" sources.gwq-darwin-arm64.version;
+  src = sources.gwq-darwin-arm64.src;
+
+  # The tarball has no top-level directory — the `gwq` binary sits at the root.
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 gwq $out/bin/gwq
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Git worktree manager with fuzzy finder, designed as the worktree counterpart to ghq";
+    homepage = "https://github.com/d-kuro/gwq";
+    changelog = "https://github.com/d-kuro/gwq/releases/tag/${sources.gwq-darwin-arm64.version}";
+    license = lib.licenses.asl20;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "gwq";
+    platforms = [ "aarch64-darwin" ];
+  };
+}


### PR DESCRIPTION
Closes #362

## Problem

`hosts/common/packages.nix` built `gwq` 0.0.19 and `home/gh.nix` built `gh-sub-issue` 0.5.1 inline with `buildGoModule`, hand-maintained hashes embedded in the modules.
They were invisible to the daily nvfetcher update workflow — `gwq` had silently gone stale at 0.0.19 while upstream is at v0.1.1.

## Change

Both upstreams publish official prebuilt darwin-arm64 release binaries, so both move to `pkgs/` following the established pattern (`ax`, `octorus`, `vize`, `vite-plus`):

- `pkgs/gwq.nix` — goreleaser tarball, `versionCheckHook` asserts the binary reports the tracked version
- `pkgs/gh-sub-issue.nix` — bare binary asset; `pname` and the binary name stay `gh-sub-issue` so `programs.gh.extensions`' linkFarm wiring is unchanged
- Versions and hashes tracked in `nvfetcher.toml` (`gwq` v0.1.1, `gh-sub-issue` 0.5.1); future releases arrive via the daily update PR
- The inline `buildGoModule` definitions are deleted

`gwq` jumps 0.0.19 → 0.1.1 as part of the migration.

## Verification

- `nix build .#gwq` — `gwq --version` reports `v0.1.1` (also asserted in `installCheckPhase`)
- `nix build .#gh-sub-issue` — `--help` prints the extension usage
- `environment.systemPackages` evaluates to `gwq-0.1.1`; `programs.gh.extensions` evaluates to `gh-sub-issue-0.5.1` + `gh-dash`
- `nix fmt` reports no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)