### PR TITLE
fix: silence getExe deprecation warning for jsonnet

### DIFF
--- a/home/vscode.nix
+++ b/home/vscode.nix
@@ -12,7 +12,7 @@ let
   # fails the build instead of silently corrupting the output the way the
   # previous regex-based conversion could (issue #364).
   keybindings-json = pkgs.runCommand "keybindings.json" { } ''
-    ${lib.getExe pkgs.jsonnet} ${inputs.vscode-settings}/keybinding.jsonc -o $out
+    ${lib.getExe' pkgs.jsonnet "jsonnet"} ${inputs.vscode-settings}/keybinding.jsonc -o $out
   '';
 in
 {


### PR DESCRIPTION
nixpkgs' `jsonnet` does not set `meta.mainProgram`, so every evaluation of `home/vscode.nix` emitted:

> warning: getExe: Package "jsonnet-0.21.0" does not have the meta.mainProgram attribute. …

Name the program explicitly with `lib.getExe'`. Evaluation is now warning-free; the derivation is unchanged in substance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)