### PR TITLE
fix(docs): resolve Dependabot alerts for hono, postcss, undici

### DIFF
--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   esbuild: '>=0.28.1'
   sharp: ^0.35.0
   ws: ^8.21.0
-  undici: ^7.28.0
+  undici: ^7.29.0
 
 importers:
 
@@ -1751,8 +1751,8 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.13.1:
+    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
   ieee754@1.2.1:
@@ -1885,8 +1885,8 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1993,8 +1993,8 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
-  postcss@8.5.22:
-    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -2112,8 +2112,8 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
@@ -2148,8 +2148,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -2226,6 +2226,18 @@ packages:
 
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2350,7 +2362,7 @@ snapshots:
       '@cloudflare/containers': 0.3.7
       aws4fetch: 1.0.20
       capnweb: 0.8.0
-      hono: 4.12.31
+      hono: 4.13.1
 
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260721.1)':
     dependencies:
@@ -2488,9 +2500,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@hono/oauth-providers@0.8.6(hono@4.12.31)':
+  '@hono/oauth-providers@0.8.6(hono@4.13.1)':
     dependencies:
-      hono: 4.12.31
+      hono: 4.13.1
 
   '@img/colour@1.1.0': {}
 
@@ -2942,7 +2954,7 @@ snapshots:
       '@oxc-project/runtime': 0.133.0
       '@oxc-project/types': 0.133.0
       lightningcss: 1.33.0
-      postcss: 8.5.22
+      postcss: 8.5.26
     optionalDependencies:
       esbuild: 0.28.1
       fsevents: 2.3.3
@@ -2954,7 +2966,7 @@ snapshots:
       '@oxc-project/runtime': 0.139.0
       '@oxc-project/types': 0.139.0
       lightningcss: 1.33.0
-      postcss: 8.5.22
+      postcss: 8.5.26
       yuku-codegen: 0.5.48
       yuku-parser: 0.5.48
     optionalDependencies:
@@ -2993,10 +3005,10 @@ snapshots:
       sirv: 3.0.2
       std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       vite: '@voidzero-dev/vite-plus-core@0.2.5(esbuild@0.28.1)(tsx@4.23.1)(typescript@6.0.3)'
-      ws: 8.21.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@tsdown/css'
@@ -3047,7 +3059,7 @@ snapshots:
       '@vue/shared': 3.5.40
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.22
+      postcss: 8.5.26
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.40':
@@ -3357,7 +3369,7 @@ snapshots:
 
   github-from-package@0.0.0: {}
 
-  hono@4.12.31: {}
+  hono@4.13.1: {}
 
   ieee754@1.2.1: {}
 
@@ -3438,7 +3450,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260721.1
       ws: 8.21.1
       youch: 4.1.0-beta.10
@@ -3453,7 +3465,7 @@ snapshots:
 
   mrmime@2.0.1: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanostores@1.4.1: {}
 
@@ -3576,9 +3588,9 @@ snapshots:
 
   pngjs@7.0.0: {}
 
-  postcss@8.5.22:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3727,7 +3739,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.2.4: {}
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -3755,7 +3767,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -3832,7 +3844,7 @@ snapshots:
       '@cloudflare/sandbox': 0.10.3
       '@cloudflare/vite-plugin': 1.46.0(@voidzero-dev/vite-plus-core@0.2.5(esbuild@0.28.1)(tsx@4.23.1)(typescript@6.0.3))(wrangler@4.113.0(@cloudflare/workers-types@4.20260702.1))
       '@cloudflare/workers-types': 4.20260702.1
-      '@hono/oauth-providers': 0.8.6(hono@4.12.31)
+      '@hono/oauth-providers': 0.8.6(hono@4.13.1)
       '@napi-rs/keyring': 1.3.0
       better-auth: 1.6.24(@cloudflare/workers-types@4.20260702.1)(@voidzero-dev/vite-plus-test@0.1.24(@voidzero-dev/vite-plus-core@0.2.5(esbuild@0.28.1)(tsx@4.23.1)(typescript@6.0.3))(esbuild@0.28.1)(tsx@4.23.1)(typescript@6.0.3))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(kysely@0.29.4)(pg@8.22.0))(pg@8.22.0)(vue@3.5.40(typescript@6.0.3))
       better-sqlite3: 12.11.1
@@ -3843,7 +3855,7 @@ snapshots:
       drizzle-valibot: 0.4.2(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(kysely@0.29.4)(pg@8.22.0))(valibot@1.4.2(typescript@6.0.3))
       drizzle-zod: 0.8.3(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(kysely@0.29.4)(pg@8.22.0))(zod@4.4.3)
       es-module-lexer: 2.3.1
-      hono: 4.12.31
+      hono: 4.13.1
       ignore: 7.0.6
       jsonc-parser: 3.3.1
       pg: 8.22.0
@@ -3939,6 +3951,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.1: {}
+
+  ws@8.21.3: {}
 
   xtend@4.0.2: {}
 

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   # (miniflare/wrangler pin ws/undici exactly; sharp 0.35 is outside miniflare's ^0.34.5)
   sharp: ^0.35.0
   ws: ^8.21.0
-  undici: ^7.28.0
+  undici: ^7.29.0
 overrides:
   vite: "catalog:"
   vitest: "catalog:"


### PR DESCRIPTION
## Summary

Clears all 10 open Dependabot alerts, which all live in `docs/pnpm-lock.yaml`:

| Package | Before | After | Alerts fixed |
|---|---|---|---|
| undici | 7.28.0 | 7.29.0 | 5 (1 high: cross-user info disclosure via cache directives) |
| hono | 4.12.31 | 4.13.1 | 4 (SSR `memo()` cross-user disclosure, CORS ReDoS, etc.) |
| postcss | 8.5.22 | 8.5.26 | 1 (arbitrary `.map` read via sourceMappingURL) |

The undici bump goes through the existing security-floor pattern in `pnpm-workspace.yaml` (`^7.28.0` → `^7.29.0`); hono and postcss are in-range lockfile updates.

## Note: vite-plus kept at locked versions

Re-resolving the `latest` catalog entries pulls vite-plus 0.2.9, whose native binding layout (`vite-plus/binding` export removed) is incompatible with `vite-plus-test@0.1.24`'s pinned `core@0.1.24`, crashing `vp check` / `vp build`. The update was therefore done with the toolchain temporarily pinned, leaving vite-plus at 0.2.5 exactly as on `main`.

## Verification

- `pnpm install --frozen-lockfile` passes (lockfile consistent)
- `vp check` passes (format / lint / type check, 49 files)
- `vp build` passes
- `vp test` fails identically on `main` (missing `vitest` bin in `vite-plus-test@0.1.24` — pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)