### PR TITLE
feat: add frog as nvfetcher-managed pkg

### DIFF
--- a/hosts/common/packages.nix
+++ b/hosts/common/packages.nix
@@ -27,6 +27,7 @@ in
     darwin-rebuild-nom
     devenv
     fd
+    frog
     fzf
     gh
     ghq

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -38,6 +38,13 @@ fetch.url = "https://github.com/voidzero-dev/vite-plus/releases/download/$ver/vp
 src.github = "microsoft/playwright-cli"
 fetch.github = "microsoft/playwright-cli"
 
+# Release tags carry an npm-style "frog@" prefix, stripped here so $ver is
+# the bare version. The release asset is a gzipped single binary.
+[frog-darwin-arm64]
+src.github = "wevm/frog"
+src.prefix = "frog@"
+fetch.url = "https://github.com/wevm/frog/releases/download/frog@$ver/frog-darwin-arm64.gz"
+
 # The published npm tarball bundles all dependencies (rollup) and ships the
 # built JS, so it is consumed directly — no npm install, no TypeScript build.
 # Release tags carry a "chrome-devtools-mcp-v" prefix, stripped here so $ver

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -29,6 +29,21 @@
         },
         "version": "1.7.0"
     },
+    "frog-darwin-arm64": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "frog-darwin-arm64",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-9QbnCokyF7VHcRpyy/S9pnZ6FcI2YBzg1gAhlcI3+pM=",
+            "type": "url",
+            "url": "https://github.com/wevm/frog/releases/download/frog@1.1.0/frog-darwin-arm64.gz"
+        },
+        "version": "1.1.0"
+    },
     "gh-sub-issue-darwin-arm64": {
         "cargoLock": null,
         "date": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -22,6 +22,14 @@
       sha256 = "sha256-iVczWGoOzhOEk3kMB+iwg7hXGx0gN6cxJDNNlo0QRtA=";
     };
   };
+  frog-darwin-arm64 = {
+    pname = "frog-darwin-arm64";
+    version = "1.1.0";
+    src = fetchurl {
+      url = "https://github.com/wevm/frog/releases/download/frog@1.1.0/frog-darwin-arm64.gz";
+      sha256 = "sha256-9QbnCokyF7VHcRpyy/S9pnZ6FcI2YBzg1gAhlcI3+pM=";
+    };
+  };
   gh-sub-issue-darwin-arm64 = {
     pname = "gh-sub-issue-darwin-arm64";
     version = "0.5.1";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,6 +7,7 @@ in
 {
   ax = pkgs.callPackage ./ax.nix { inherit sources; };
   chrome-devtools-mcp = pkgs.callPackage ./chrome-devtools-mcp.nix { inherit sources; };
+  frog = pkgs.callPackage ./frog.nix { inherit sources; };
   gh-sub-issue = pkgs.callPackage ./gh-sub-issue.nix { inherit sources; };
   gwq = pkgs.callPackage ./gwq.nix { inherit sources; };
   octorus = pkgs.callPackage ./octorus.nix { inherit sources; };

--- a/pkgs/frog.nix
+++ b/pkgs/frog.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenvNoCC,
+  sources,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "frog";
+  version = sources.frog-darwin-arm64.version;
+  src = sources.frog-darwin-arm64.src;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/bin
+    gunzip -c $src > $out/bin/frog
+    chmod 755 $out/bin/frog
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/frog --version > /dev/null
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Automated friction logging for agents";
+    homepage = "https://frog.fm";
+    changelog = "https://github.com/wevm/frog/releases/tag/frog@${sources.frog-darwin-arm64.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "frog";
+    platforms = [ "aarch64-darwin" ];
+  };
+}


### PR DESCRIPTION
## Summary

Adds [wevm/frog](https://github.com/wevm/frog) ("Automated friction logging for agents", https://frog.fm) as a globally installed CLI, following the repo's ax pattern for non-nixpkgs tools:

- `nvfetcher.toml`: new `frog-darwin-arm64` entry tracking the official prebuilt release binary (`frog-darwin-arm64.gz`). Release tags carry an npm-style `frog@` prefix, stripped with `src.prefix` so `$ver` is the bare version.
- `pkgs/frog.nix`: gunzips the single binary, installs it as `bin/frog`, with an install check running `frog --version`.
- `pkgs/_sources`: regenerated with `-f '^frog-darwin-arm64$'` — only the frog entry added, no other packages touched.
- `hosts/common/packages.nix`: added to `environment.systemPackages`.

Per the discussion in #385: the CLI is installed globally (single binary, no repo-specific state); friction-log entries themselves stay out of git. This PR contains no `frog init` artifacts.

## Verification

- `nix build .#frog` succeeds; `result/bin/frog --version` → `1.1.0`
- Darwin configurations evaluate with the new package in `systemPackages`

Part of #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)