### PR TITLE
feat: set up frog friction logging

### DIFF
--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -1,0 +1,39 @@
+# Friction log
+
+Friction hit while working in this repository, one directory per item:
+
+```
+<id>/
+  friction.md   the write-up
+  artifacts/    optional, whatever reproduces it
+```
+
+Reporting an entry gives it an owner. The write-up then carries an `issue:` link and mirrors what happens
+to it. The whole directory is deleted once the friction is resolved. Every entry left here is still
+outstanding, including friction in dependencies.
+
+Do not maintain an index here. This directory is the index.
+
+## Logging Friction
+
+```sh
+frog list    # what is already known
+frog log     # add one
+```
+
+`frog log` writes the sections to fill in. Each id is when the friction was hit plus its title, so
+the directory reads oldest-first.
+
+Put anything that reproduces the friction in that entry's `artifacts/` and reference it from the
+write-up. The next reader runs the reproduction instead of rebuilding it.
+
+## For Agents
+
+Add these rules near the top of `AGENTS.md`, under the appropriate section. Create the file if missing; otherwise amend it in place, preserve all existing content, and never replace the file.
+
+- If `frog` is not installed, install the binary: `curl -fsSL https://frog.fm/install | sh`.
+- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `frog log`.
+- Do not add global, system, or internal friction.
+- Run `frog list` first to see what is already known.
+
+Managed by [Frog](https://github.com/wevm/frog).

--- a/.agents/friction-log/config.json
+++ b/.agents/friction-log/config.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://unpkg.com/frog/schema.json",
+  "inbound": {
+    "enabled": true
+  }
+}

--- a/.github/ISSUE_TEMPLATE/friction.yml
+++ b/.github/ISSUE_TEMPLATE/friction.yml
@@ -1,0 +1,34 @@
+name: Friction
+description: Something about this project cost you time.
+labels: [friction]
+body:
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: Describe what should happen.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: Describe what happens instead.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Possible Solution
+      description: Optional. Suggest a fix or a reason for the friction.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Minimal Reproducible Example
+      description: Add a minimal reproducible example under `artifacts/`, or an unambiguous set of steps to reproduce this. Include code where relevant.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Context
+      description: Describe how this affected you, and what you were trying to accomplish.
+    validations:
+      required: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 result
 .void/
+
+# frog friction-log entries stay local. The global gitignore (home/git.nix)
+# ignores .agents/ wholesale; re-include only the declarative bits here.
+!.agents/
+.agents/friction-log/*
+!.agents/friction-log/config.json
+!.agents/friction-log/README.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+## Friction logging (frog)
+
+- Run `frog list` first to see what is already known
+- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `frog log`
+- Do not add global, system, or internal friction
+- `frog` is installed system-wide via Nix (`pkgs/frog.nix`); never install it ad hoc
+- Entries under `.agents/friction-log/` are intentionally untracked in this repository; file an issue explicitly with `frog publish` when an entry deserves an owner

--- a/home/git.nix
+++ b/home/git.nix
@@ -15,6 +15,10 @@
       # Dummy file for VSCode file nesting. Nests config files under it to reduce clutter in project roots.
       # Related: https://github.com/naitokosuke/vscode-settings (explorer.fileNesting.patterns)
       "___config___"
+      # frog friction logs (https://frog.fm) stay local by default. Kept as a
+      # directory-level pattern so a repo that wants them tracked can re-include
+      # with "!.agents/" in its own .gitignore (issue #385).
+      ".agents/"
     ];
     settings = {
       user = {


### PR DESCRIPTION
## Summary

Second half of #385: wire up [frog](https://frog.fm) friction logging with the "local entries, explicit opt-in for tracking" policy.

### Global gitignore (`home/git.nix`)

`.agents/` is ignored globally, so `frog log` entries stay local in every repository by default. The pattern is deliberately directory-level so a repository that wants friction logs tracked can re-include them with `!.agents/` in its own `.gitignore`.

### This repository (`frog init` artifacts)

Uses that re-include mechanism to track only the declarative bits:

- `.agents/friction-log/config.json` — declares `inbound.enabled` on the default branch, so agents in other repositories can report dotfiles-caused friction here via `frog log --target naitokosuke/dotfiles`
- `.agents/friction-log/README.md` — explains the log to readers
- `.github/ISSUE_TEMPLATE/friction.yml` — the issue form frog publishes entries with
- `AGENTS.md` — frog usage rules for agents, adapted for Nix (no ad-hoc installs)

Entries themselves stay untracked; publishing to GitHub issues is manual (`frog publish`). No automation workflow and no GitHub App.

## Verification

- `git check-ignore -v`: entry dirs ignored, `config.json`/`README.md` re-included, `result` still ignored
- Darwin config evaluates; `programs.git.ignores` includes `.agents/`
- treefmt: no changes

Closes #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)