### PR TITLE
refactor(claude): declarative settings.json + fix playwright-cli hash

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -1,125 +1,92 @@
 {
   config,
-  pkgs,
   lib,
   inputs,
   ...
 }:
 
-let
-  # ~/.claude/settings.json must stay a writable real file, not a store
-  # symlink: Claude Code writes runtime state into it (model, language,
-  # enabledPlugins, plugin hooks, ...). Copying it only when missing kept
-  # those runtime edits but silently dropped every later change to the
-  # declared settings (issue #361), so the activation instead deep-merges
-  # the declared settings into the live file on every rebuild:
-  #   - declared keys are authoritative (arrays are replaced wholesale)
-  #   - keys that exist only in the live file survive
-  claudeSettings = pkgs.writeText "claude-settings.json" (
-    builtins.toJSON {
-      installMethod = "unknown";
-      autoUpdates = true;
-      theme = "dark-daltonized";
-      verbose = false;
-      preferredNotifChannel = "auto";
-      shiftEnterKeyBindingInstalled = true;
-      editorMode = "normal";
-      spinnerVerbs = {
-        mode = "replace";
-        verbs = [
-          "考え中"
-          "深く考え中"
-          "実装中"
-          "リファクタリング中"
-          "調査中"
-        ];
-      };
-      hasUsedBackslashReturn = true;
-      autoCompactEnabled = true;
-      diffTool = "auto";
-      env = {
-        DISABLE_AUTOUPDATER = "1";
-        DISABLE_INSTALLATION_CHECKS = "1";
-      };
-      todoFeatureEnabled = true;
-      messageIdleNotifThresholdMs = 60000;
-      autoConnectIde = false;
-      autoInstallIdeExtension = true;
-      checkpointingEnabled = true;
-      # Permissions reference:
-      #   https://code.claude.com/docs/en/permissions
-      #   https://www.claudedirectory.org/blog/claude-code-permissions-guide
-      #   https://www.backslash.security/blog/claude-code-security-best-practices
-      # Known issue (deny may be ignored on older versions): https://github.com/anthropics/claude-code/issues/6699
-      permissions = {
-        deny = [
-          # Joke: discourage legacy / non-preferred runtimes
-          "Bash(perl:*)"
-          "Bash(python:*)"
-          "Bash(python3:*)"
-
-          # Credentials and secrets (gitignore semantics, recursive)
-          "Read(.env)"
-          "Read(.env.*)"
-          "Read(./secrets/**)"
-          "Read(**/credentials.json)"
-          "Read(~/.ssh/**)"
-          "Read(~/.aws/**)"
-          "Read(~/.gnupg/**)"
-
-          # Destructive shell — root / home wipes still trip the circuit breaker,
-          # but make it explicit
-          "Bash(rm -rf /:*)"
-          "Bash(rm -rf ~:*)"
-          "Bash(rm -rf ~/:*)"
-
-          # Force-push protection (regular push stays in `ask`/allow)
-          "Bash(git push --force:*)"
-          "Bash(git push -f:*)"
-          "Bash(git push * --force:*)"
-          "Bash(git push * -f:*)"
-
-          # Prefer WebFetch with explicit domain over raw curl/wget
-          "Bash(curl:*)"
-          "Bash(wget:*)"
-        ];
-      };
-      hooks = {
-        PreToolUse = [
-          {
-            matcher = "ExitPlanMode";
-            hooks = [
-              {
-                type = "command";
-                command = ''code "$(ls -t ~/.claude/plans/*.md | head -1)"'';
-                timeout = 5;
-              }
-            ];
-          }
-        ];
-      };
-    }
-  );
-in
 {
-  home.activation.claudeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    target="$HOME/.claude/settings.json"
-    run mkdir -p "$HOME/.claude"
-    # Drop the store symlink left behind by the pre-2026 home.file approach
-    [ -L "$target" ] && run rm "$target"
-    if [ ! -f "$target" ]; then
-      run install -m 644 ${claudeSettings} "$target"
-    else
-      merged="$HOME/.claude/.settings.json.merged"
-      ${lib.getExe pkgs.jq} -s '.[0] * .[1]' "$target" ${claudeSettings} > "$merged"
-      if ${pkgs.diffutils}/bin/cmp -s "$merged" "$target"; then
-        rm -f "$merged"
-      else
-        run mv "$merged" "$target"
-        rm -f "$merged"
-      fi
-    fi
-  '';
+  # settings.json is generated declaratively by programs.claude-code as a
+  # read-only store symlink. Nix is the single source of truth; runtime edits
+  # are not persisted back.
+  programs.claude-code.settings = {
+    installMethod = "unknown";
+    autoUpdates = true;
+    theme = "dark-daltonized";
+    verbose = false;
+    preferredNotifChannel = "auto";
+    shiftEnterKeyBindingInstalled = true;
+    editorMode = "normal";
+    spinnerVerbs = {
+      mode = "replace";
+      verbs = [
+        "考え中"
+        "深く考え中"
+        "実装中"
+        "リファクタリング中"
+        "調査中"
+      ];
+    };
+    hasUsedBackslashReturn = true;
+    autoCompactEnabled = true;
+    diffTool = "auto";
+    env = {
+      DISABLE_AUTOUPDATER = "1";
+      DISABLE_INSTALLATION_CHECKS = "1";
+    };
+    todoFeatureEnabled = true;
+    messageIdleNotifThresholdMs = 60000;
+    autoConnectIde = false;
+    autoInstallIdeExtension = true;
+    checkpointingEnabled = true;
+    permissions = {
+      deny = [
+        # Joke: discourage legacy / non-preferred runtimes
+        "Bash(perl:*)"
+        "Bash(python:*)"
+        "Bash(python3:*)"
+
+        # Credentials and secrets (gitignore semantics, recursive)
+        "Read(.env)"
+        "Read(.env.*)"
+        "Read(./secrets/**)"
+        "Read(**/credentials.json)"
+        "Read(~/.ssh/**)"
+        "Read(~/.aws/**)"
+        "Read(~/.gnupg/**)"
+
+        # Destructive shell — root / home wipes still trip the circuit breaker,
+        # but make it explicit
+        "Bash(rm -rf /:*)"
+        "Bash(rm -rf ~:*)"
+        "Bash(rm -rf ~/:*)"
+
+        # Force-push protection (regular push stays in `ask`/allow)
+        "Bash(git push --force:*)"
+        "Bash(git push -f:*)"
+        "Bash(git push * --force:*)"
+        "Bash(git push * -f:*)"
+
+        # Prefer WebFetch with explicit domain over raw curl/wget
+        "Bash(curl:*)"
+        "Bash(wget:*)"
+      ];
+    };
+    hooks = {
+      PreToolUse = [
+        {
+          matcher = "ExitPlanMode";
+          hooks = [
+            {
+              type = "command";
+              command = ''code "$(ls -t ~/.claude/plans/*.md | head -1)"'';
+              timeout = 5;
+            }
+          ];
+        }
+      ];
+    };
+  };
 
   # Claude Code rules, CLAUDE.md and skills - out-of-store symlinks into the
   # rule-rule-rule / skill-skill-skill repositories.

--- a/pkgs/playwright-cli.nix
+++ b/pkgs/playwright-cli.nix
@@ -16,7 +16,7 @@ buildNpmPackage {
 
   # Not tracked by nvfetcher — update by hand when the version bumps;
   # the build fails loudly on a stale hash.
-  npmDepsHash = "sha256-u44jWprmr3RdzB3aDL3K0ShT5lLxr175z3C8pN43YFA=";
+  npmDepsHash = "sha256-3kqiQvGtZfsmLHVWeCSM1yOYb+ws2x1vMPC1OuvrKAI=";
 
   dontNpmBuild = true;
 


### PR DESCRIPTION
## What

- **fix(playwright-cli)**: update stale `npmDepsHash` for 0.1.18 (was blocking `darwin-rebuild build`).
- **refactor(claude)**: generate `~/.claude/settings.json` declaratively via `programs.claude-code.settings` instead of the imperative `home.activation` deep-merge.

## Why

The `home.activation.claudeSettings` script `mv`'d a merged file onto `settings.json`. When that file was mode `0444`, `mv` prompted `overriding mode 0444?` and **stalled activation** waiting for input. Rather than patch the script, the settings now come from the `programs.claude-code` module, which writes `settings.json` as a read-only store symlink — fully declarative, no activation script.

## Behavior change

`settings.json` is now read-only; Claude Code runtime edits are no longer persisted back (Nix is the single source of truth). On first switch the existing writable file is backed up by home-manager.

## Verified

`darwin-rebuild switch --flake .#Mac-big` completes; `settings.json` is a store symlink, no `claudeSettings` activation remains, `.claude/skills` links intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)