### PR TITLE
feat: install idris2 globally

### DIFF
--- a/docs/src/explanations.ts
+++ b/docs/src/explanations.ts
@@ -392,25 +392,19 @@ export const explanations: Readonly<Record<string, Explanation>> = {
     tags: ["cli", "packages"],
     walkthrough: {
       intro:
-        "The system CLI toolbelt. Everything here is on `$PATH` for every user and login shell. Locally-built tools live alongside nixpkgs: `gwq` (worktree-aware git helper), `darwin-rebuild-nom` (pipes `darwin-rebuild` through `nix-output-monitor`), and the nvfetcher-tracked overlay packages from `./pkgs` (`ax`, `octorus`, `vite-plus`, `vize`).",
+        "The system CLI toolbelt. Everything here is on `$PATH` for every user and login shell. The only derivation defined inline is `darwin-rebuild-nom` (pipes `darwin-rebuild` through `nix-output-monitor`); the rest come from nixpkgs, from the nvfetcher-tracked overlay in `./pkgs` (`ax`, `frog`, `gwq`, `octorus`, `vite-plus`, `vize`, …), or from a flake input.",
       sections: [
-        {
-          title: "gwq, built from source",
-          prose:
-            "`gwq` isn't in nixpkgs yet, so we build it ourselves with `buildGoModule`. `vendorHash` pins the Go module graph, and `doCheck = false` skips the upstream tests that need a writable HOME and `git` on PATH (both fight the Nix sandbox).",
-          lines: [8, 24],
-        },
         {
           title: "darwin-rebuild-nom wrapper",
           prose:
             "`darwin-rebuild` doesn't accept `--log-format`, so we wrap it in a shell script that pipes stderr through `nix-output-monitor`. The result is the same rebuild command but with the richer progress UI Nix-flavoured CIs use.",
-          lines: [26, 35],
+          lines: [7, 18],
         },
         {
           title: "The CLI toolbelt",
           prose:
-            "Daily drivers: `gh`, `ghq`, `git`, `fd`, `fzf`, `ripgrep`, `sd`, `bun`, `pnpm`, `nodejs_24`. Nix workflow tools: `nixd`, `devenv`, `nix-output-monitor`, plus the locally-built `darwin-rebuild-nom`. `ax`, `octorus`, `vite-plus` (`vp`), and `vize` are the nvfetcher-tracked overlay packages from `./pkgs`; only `herdr` is still wired in via a flake input.",
-          lines: [38, 67],
+            "Daily drivers: `gh`, `ghq`, `git`, `fd`, `fzf`, `ripgrep`, `sd`, `bun`, `pnpm`, `nodejs_24`. Language toolchains that should be available outside any project shell: `rustup`, `uv`, and `idris2`. Nix workflow tools: `nixd`, `devenv`, `nix-output-monitor`, plus the locally-built `darwin-rebuild-nom`. `ax`, `frog`, `gwq`, `octorus`, `playwright-cli`, `vite-plus` (`vp`), and `vize` come from the `./pkgs` overlay; only `herdr` is still wired in via a flake input.",
+          lines: [20, 55],
         },
       ],
     },

--- a/hosts/common/packages.nix
+++ b/hosts/common/packages.nix
@@ -35,6 +35,7 @@ in
     gomi
     gwq
     inputs.herdr.packages.${pkgs.stdenv.hostPlatform.system}.default
+    idris2
     ni
     nixd
     nix-output-monitor


### PR DESCRIPTION
Closes #391

## What

* Add `idris2` (nixpkgs 0.8.0) to `environment.systemPackages` in `hosts/common/packages.nix`, so it is on `$PATH` for every user and login shell on both hosts.
* Refresh the `hosts/common/packages.nix` walkthrough in `docs/src/explanations.ts`.

## Why the walkthrough changed

The walkthrough was stale. It still carried a "gwq, built from source" section describing a `buildGoModule` derivation that moved out to `pkgs/gwq.nix` in 653d677, and every `lines` range pointed at the wrong part of the file (the toolbelt range ended past the end of it). This drops the dead section, re-anchors the two remaining ranges, and updates the prose to cover the current overlay packages plus the language toolchains, `idris2` included.

## Verification

* `nix build .#darwinConfigurations.Mac-big.system --dry-run` resolves; `idris2` comes from the binary cache, only the wrapper derivation builds locally.
* `vp check` passes (format, lint, type-check).
* `vp run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)