### PR TITLE
feat: switch system Node.js to 26

### DIFF
--- a/hosts/common/packages.nix
+++ b/hosts/common/packages.nix
@@ -39,7 +39,7 @@ in
     ni
     nixd
     nix-output-monitor
-    nodejs_24
+    nodejs_26
     octorus
     oxfmt
     playwright-cli


### PR DESCRIPTION
## Summary

- Replace `nodejs_24` with `nodejs_26` in `hosts/common/packages.nix`
- Node 26 (26.7.0) is the Current release and enters Active LTS on 2026-10-28; Node 25 is already EOL and removed from nixpkgs

## Verification

- `darwin-rebuild build` succeeds
- Applied on Macbook-heavy via `darwin-rebuild switch`: `node --version` → v26.7.0, pnpm/npm working

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXonLzrEgZThbbe1RXNkcd